### PR TITLE
Remove c accounts from carr calculation

### DIFF
--- a/backend/src/projects/salesforce/index.js
+++ b/backend/src/projects/salesforce/index.js
@@ -249,14 +249,23 @@ router.get('/report/:reportId', authenticateToken, async (req, res) => {
         }
 
         // Recalculate totals for filtered opportunities
-        const filteredTotalCARR = opportunities.reduce((sum, opp) => sum + opp.carrAmount, 0);
+        // Exclude C accounts from quarterly metrics
+        const filteredOpportunities = opportunities.filter((opp) => opp.accountScore !== 'C');
+
+        const filteredTotalCARR = filteredOpportunities.reduce(
+          (sum, opp) => sum + opp.carrAmount,
+          0,
+        );
 
         quarterlyData[quarterName] = {
           quarter: quarterName,
           totalCARR: filteredTotalCARR,
-          totalCARRFormatted: `$${filteredTotalCARR.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
-          opportunityCount: opportunities.length,
-          opportunities: opportunities,
+          totalCARRFormatted: `$${filteredTotalCARR.toLocaleString('en-US', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })}`,
+          opportunityCount: filteredOpportunities.length,
+          opportunities: filteredOpportunities,
         };
       });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.17.1",
+        "all": "^0.0.0",
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -1322,6 +1323,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/all": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/all/-/all-0.0.0.tgz",
+      "integrity": "sha512-0oKlfNVv2d+d7c1gwjGspzgbwot47PGQ4b3v1ccx4mR8l9P/Y6E6Dr/yE8lNT63EcAKEbHo6UG3odDpC/NQcKw==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.17.1",
+    "all": "^0.0.0",
     "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",


### PR DESCRIPTION
C accounts are no longer included in CARR calculations for the Den page or the Bounty Page.

CARR calculation filter was not excluding C accounts, but it is now.