### PR TITLE
feat(flow-doc): bulk Howl Sheet generation, helper files, and Save to Opp

### DIFF
--- a/backend/src/projects/flow-doc-generator/routes/index.js
+++ b/backend/src/projects/flow-doc-generator/routes/index.js
@@ -1,12 +1,20 @@
 import express from 'express';
+import path from 'path';
 import { anthropicService } from '../../../services/anthropicService.js';
 
 const router = express.Router();
 
 /**
  * Parse a QA Wolf app URL into environmentId, relativePath, and the API base URL.
- * Expected format:
- *   https://app.qawolf.com/<org>/environments/<ENV_ID>/automate/ide?file=src%2Fflows%2Fsome-flow.flow.js
+ *
+ * Supports two shapes:
+ *   Single flow URL (has a ?file= param):
+ *     https://app.qawolf.com/<org>/environments/<ENV_ID>/automate/ide?file=src%2Fflows%2Fsome-flow.flow.js
+ *   Environment URL (no ?file= param), used for bulk generation:
+ *     https://app.qawolf.com/<org>/environments/<ENV_ID>/automate/ide
+ *
+ * `relativePath` is `null` when no ?file= param is present so callers can decide
+ * whether a file is required (single) or optional (bulk).
  *
  * The tRPC base URL is derived from the pasted URL's origin so prod/staging URLs
  * always hit the correct host regardless of the QAW_BASE_URL env var.
@@ -29,12 +37,6 @@ function parseQawolfUrl(flowUrl) {
 
   const environmentId = segments[envIndex + 1];
   const relativePath = parsed.searchParams.get('file');
-
-  if (!relativePath) {
-    throw new Error(
-      'Could not extract file path from URL. Make sure the URL contains a ?file= query parameter.',
-    );
-  }
 
   // Derive tRPC base from the URL origin so prod and staging URLs both work
   const trpcBase = `${parsed.origin}/api/trpc`;
@@ -124,9 +126,347 @@ function extractTestSteps(source) {
   return steps;
 }
 
+/**
+ * Pull import/require specifiers out of flow source code so we can resolve them
+ * to helper/utility files. QA Wolf flows reference utilities both relatively
+ * (`../utilities/foo`) and via the tsconfig baseUrl (`utilities/foo`), so we
+ * capture every specifier and let `resolveHelperPaths` decide which ones map to
+ * real first-party files in the environment tree (node modules simply won't
+ * match anything in the tree and get dropped there).
+ */
+function extractImportPaths(source) {
+  const specifiers = new Set();
+
+  // import ... from '<spec>'  and  import '<spec>'
+  const importRegex = /import\s+(?:[^'"]*?\s+from\s+)?["']([^"']+)["']/g;
+  // require('<spec>')
+  const requireRegex = /require\(\s*["']([^"']+)["']\s*\)/g;
+
+  for (const regex of [importRegex, requireRegex]) {
+    let match;
+    while ((match = regex.exec(source)) !== null) {
+      specifiers.add(match[1]);
+    }
+  }
+
+  return [...specifiers];
+}
+
+const HELPER_EXTENSIONS = ['.ts', '.js', '.tsx', '.jsx', '.mjs', '.cjs'];
+const HELPER_EXT_RE = /\.(ts|js|tsx|jsx|mjs|cjs)$/;
+// Directories that hold first-party shared helpers in a QA Wolf repo.
+const HELPER_DIR_RE = /(^|\/)(utilities|helpers|lib)\//;
+
+function stripHelperExt(p) {
+  return p.replace(HELPER_EXT_RE, '');
+}
+
+/**
+ * Given a base path (no extension assumed), return the first matching file in
+ * the tree, trying the path as-is, with each helper extension, and as an
+ * index file.
+ */
+function matchInTree(base, knownPaths) {
+  if (HELPER_EXT_RE.test(base)) {
+    return knownPaths.has(base) ? base : null;
+  }
+  for (const ext of HELPER_EXTENSIONS) {
+    if (knownPaths.has(base + ext)) return base + ext;
+  }
+  for (const ext of HELPER_EXTENSIONS) {
+    if (knownPaths.has(`${base}/index${ext}`)) return `${base}/index${ext}`;
+  }
+  return null;
+}
+
+/**
+ * Resolve import specifiers from a flow file into concrete repo paths, matched
+ * against the environment's real file tree. Handles three import styles:
+ *
+ *   1. Relative:        "../utilities/foo"  -> resolved against the flow's dir
+ *   2. baseUrl / alias: "utilities/foo"     -> tried as-is and under "src/"
+ *   3. Last resort:     match the specifier's basename to a file living in a
+ *      utilities/helpers/lib directory (covers odd alias configs).
+ *
+ * Only paths that actually exist in the tree are returned, so node modules and
+ * bad guesses are dropped rather than triggering 404 fetches.
+ */
+function resolveHelperPaths(relativePath, specifiers, knownPaths) {
+  const resolved = new Set();
+  if (!knownPaths || knownPaths.size === 0) return [];
+
+  const baseDir = path.posix.dirname(relativePath);
+  const knownArr = [...knownPaths];
+
+  for (const spec of specifiers) {
+    let match = null;
+
+    if (spec.startsWith('.')) {
+      // 1. Relative to the flow file.
+      match = matchInTree(path.posix.normalize(path.posix.join(baseDir, spec)), knownPaths);
+    } else {
+      // 2. baseUrl-style: try as-is, then under a "src/" root.
+      match =
+        matchInTree(spec, knownPaths) ||
+        matchInTree(path.posix.normalize(path.posix.join('src', spec)), knownPaths);
+    }
+
+    // 3. Fallback: match the basename to a file in a helper directory.
+    if (!match) {
+      const baseName = stripHelperExt(path.posix.basename(spec));
+      match =
+        knownArr.find(
+          (p) => HELPER_DIR_RE.test(p) && stripHelperExt(path.posix.basename(p)) === baseName,
+        ) || null;
+    }
+
+    if (match) resolved.add(match);
+  }
+
+  return [...resolved];
+}
+
+/**
+ * Recursively collect every string leaf in an arbitrary JSON structure.
+ * The gitwolf.getFiles response shape is not guaranteed, so we walk it
+ * defensively and pull out anything that looks like a file path.
+ */
+function collectAllStrings(node, out = []) {
+  if (node == null) return out;
+  if (typeof node === 'string') {
+    out.push(node);
+  } else if (Array.isArray(node)) {
+    for (const item of node) collectAllStrings(item, out);
+  } else if (typeof node === 'object') {
+    for (const value of Object.values(node)) collectAllStrings(value, out);
+  }
+  return out;
+}
+
+/**
+ * Walk the gitwolf.getFiles response and collect every flow file path
+ * (`*.flow.js` / `*.flow.ts`), regardless of the tree's exact shape.
+ */
+function enumerateFlowFiles(filesData) {
+  const strings = collectAllStrings(filesData);
+  const flows = new Set();
+  for (const s of strings) {
+    if (/\.flow\.(js|ts)$/.test(s)) flows.add(s);
+  }
+  return [...flows].sort();
+}
+
+/**
+ * Set of every path-like string in the file tree, used to resolve helper
+ * import specifiers to the file that actually exists.
+ */
+function collectKnownPaths(filesData) {
+  const strings = collectAllStrings(filesData);
+  const paths = new Set();
+  for (const s of strings) {
+    if (/\.[a-z0-9]+$/i.test(s) && s.includes('/')) paths.add(s);
+  }
+  return paths;
+}
+
+/**
+ * Fetch raw contents for a single file via gitwolf.getFileContents.
+ * Throws QawAuthError on 401/403 so callers can surface a 401.
+ */
+async function fetchFileContents({ trpcBase, authHeader, branchId, commitHash, filePath }) {
+  const contentsUrl = `${trpcBase}/gitwolf.getFileContents?input=${encodeURIComponent(
+    JSON.stringify({ json: { branchId, commitHash, path: filePath } }),
+  )}`;
+  const contentsRes = await fetch(contentsUrl, { headers: authHeader });
+  const rawText = await contentsRes.text();
+
+  if (contentsRes.status === 401 || contentsRes.status === 403) {
+    throw new QawAuthError();
+  }
+
+  if (!contentsRes.ok) {
+    throw new Error(`QA Wolf API returned ${contentsRes.status}: ${rawText.slice(0, 300)}`);
+  }
+
+  const contentsData = JSON.parse(rawText);
+  const data = contentsData?.result?.data?.json ?? contentsData?.result?.data ?? contentsData;
+  const fileSource = data?.content;
+
+  if (typeof fileSource !== 'string') {
+    throw new Error(`Unexpected response shape. Got keys: ${Object.keys(data || {}).join(', ')}`);
+  }
+
+  return fileSource;
+}
+
+/**
+ * Resolve the git branch/commit context for an environment and return the raw
+ * files payload so callers can also enumerate flows / resolve helpers.
+ * Throws QawAuthError on 401/403.
+ */
+async function fetchGitContext({ trpcBase, authHeader, environmentId }) {
+  const filesUrl = `${trpcBase}/gitwolf.getFiles?input=${encodeURIComponent(
+    JSON.stringify({ json: { environmentId } }),
+  )}`;
+  const filesRes = await fetch(filesUrl, { headers: authHeader });
+  const rawText = await filesRes.text();
+
+  if (filesRes.status === 401 || filesRes.status === 403) {
+    throw new QawAuthError();
+  }
+
+  if (!filesRes.ok) {
+    throw new Error(`QA Wolf API returned ${filesRes.status}: ${rawText.slice(0, 300)}`);
+  }
+
+  const filesData = JSON.parse(rawText);
+  const data = filesData?.result?.data?.json ?? filesData?.result?.data ?? filesData;
+  const branchId = data?.branch?.id;
+  const commitHash = data?.commitHash;
+
+  if (!branchId || !commitHash) {
+    throw new Error(
+      `Could not extract branch/commit info. Got keys: ${Object.keys(data || {}).join(', ')}`,
+    );
+  }
+
+  return { branchId, commitHash, filesData: data };
+}
+
+/**
+ * Generate an AI summary of a flow, including helper file source for context.
+ * Non-fatal: returns a placeholder string if the AI call fails.
+ */
+async function summarizeFlow({ relativePath, fileSource, helpers }) {
+  try {
+    const systemPrompt =
+      'You are a senior QA engineer writing professional technical documentation for a sales leave-behind document. ' +
+      'Your response must be exactly 2 - 4 sentences, no more. ' +
+      'Never use em dashes. Use plain punctuation only.';
+
+    let userPrompt =
+      `Summarize what the following QA Wolf automated test flow verifies end-to-end in exactly 2 - 4 sentences. ` +
+      `Be specific about the features and user actions covered. Stop after the second sentence.\n\n` +
+      `Flow file path: ${relativePath}\n\n` +
+      `Flow source code:\n${fileSource}`;
+
+    if (helpers && helpers.length > 0) {
+      const helperBlocks = helpers
+        .map((h) => `Helper file path: ${h.path}\n${h.code}`)
+        .join('\n\n');
+      userPrompt +=
+        `\n\nThe flow relies on the following helper files. Use them to understand shared logic, ` +
+        `but keep the summary focused on what the flow verifies:\n\n${helperBlocks}`;
+    }
+
+    let summary = await anthropicService.callAnthropic(systemPrompt, userPrompt);
+
+    // Hard-enforce 2 sentences: split after a sentence-ending punctuation
+    // followed by a capital letter.
+    const sentenceParts = summary.split(/(?<=[.!?])\s+(?=[A-Z])/);
+    if (sentenceParts.length > 2) {
+      summary = sentenceParts.slice(0, 2).join(' ').trim();
+    }
+    return summary;
+  } catch (err) {
+    console.error('Error generating summary:', err);
+    return 'AI summary unavailable. Please review the flow steps below.';
+  }
+}
+
+/**
+ * Build a full flow doc (title, summary, steps, helpers) for a single flow file.
+ * Reused by both the single-flow and bulk endpoints. Expects the caller to have
+ * already resolved the git context (branchId/commitHash) and file tree.
+ *
+ * Throws QawAuthError if fetching the main flow file fails auth (so the route
+ * can return 401). Helper fetches are best-effort and never fail the doc.
+ */
+async function generateFlowDoc({
+  trpcBase,
+  authHeader,
+  branchId,
+  commitHash,
+  relativePath,
+  orgSlug,
+  knownPaths,
+  includeHelpers = false,
+}) {
+  // 1. Fetch the main flow file
+  const fileSource = await fetchFileContents({
+    trpcBase,
+    authHeader,
+    branchId,
+    commitHash,
+    filePath: relativePath,
+  });
+
+  // 2. Optionally resolve + fetch helper files referenced via relative imports.
+  // Helpers are opt-in (best-effort): they're only useful for some flows, so we
+  // skip the extra fetches entirely unless the caller asks for them.
+  const helpers = [];
+  if (includeHelpers) {
+    const specifiers = extractImportPaths(fileSource);
+    const helperPaths = resolveHelperPaths(relativePath, specifiers, knownPaths);
+    for (const helperPath of helperPaths) {
+      try {
+        const code = await fetchFileContents({
+          trpcBase,
+          authHeader,
+          branchId,
+          commitHash,
+          filePath: helperPath,
+        });
+        helpers.push({ path: helperPath, code: code.trim() });
+      } catch (err) {
+        // Skip helpers we can't fetch (404, resolution miss, etc.) — non-fatal.
+        console.warn(`Skipping helper ${helperPath}: ${err.message}`);
+      }
+    }
+  }
+
+  // 3. Extract test steps
+  const steps = extractTestSteps(fileSource);
+
+  // 4. AI summary (includes helper context)
+  const summary = await summarizeFlow({ relativePath, fileSource, helpers });
+
+  const flowName = flowNameFromPath(relativePath);
+  const orgName = orgNameFromSlug(orgSlug);
+  const docTitle = orgName ? `${orgName} - ${flowName}` : flowName;
+
+  return {
+    flowName: docTitle,
+    filePath: relativePath,
+    summary,
+    steps,
+    helpers,
+  };
+}
+
+/**
+ * Run an async mapper over items with a bounded concurrency so bulk generation
+ * doesn't fire dozens of Anthropic calls simultaneously and trip rate limits.
+ */
+async function mapWithConcurrency(items, limit, mapper) {
+  const results = new Array(items.length);
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await mapper(items[index], index);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, worker);
+  await Promise.all(workers);
+  return results;
+}
+
 // POST /api/flow-doc/generate
 router.post('/generate', async (req, res) => {
-  const { flowUrl } = req.body;
+  const { flowUrl, includeHelpers } = req.body;
 
   if (!flowUrl || typeof flowUrl !== 'string') {
     return res.status(400).json({ error: 'flowUrl is required.' });
@@ -146,33 +486,23 @@ router.post('/generate', async (req, res) => {
     return res.status(400).json({ error: err.message });
   }
 
+  if (!relativePath) {
+    return res.status(400).json({
+      error:
+        'Could not extract file path from URL. Make sure the URL contains a ?file= query parameter, or use the environment URL for bulk generation.',
+    });
+  }
+
   const authHeader = { Authorization: `Bearer ${qawBearerToken}` };
 
-  // 2. Fetch branchId (gitWolfBranchId) and commitHash via gitwolf.getFiles
-  let gitWolfBranchId, commitHash;
+  // 2. Resolve git context (branch/commit + file tree)
+  let branchId, commitHash, filesData;
   try {
-    const filesUrl = `${trpcBase}/gitwolf.getFiles?input=${encodeURIComponent(JSON.stringify({ json: { environmentId } }))}`;
-    const filesRes = await fetch(filesUrl, { headers: authHeader });
-    const rawText = await filesRes.text();
-
-    if (filesRes.status === 401 || filesRes.status === 403) {
-      throw new QawAuthError();
-    }
-
-    if (!filesRes.ok) {
-      throw new Error(`QA Wolf API returned ${filesRes.status}: ${rawText.slice(0, 300)}`);
-    }
-
-    const filesData = JSON.parse(rawText);
-    const data = filesData?.result?.data?.json ?? filesData?.result?.data ?? filesData;
-    gitWolfBranchId = data?.branch?.id;
-    commitHash = data?.commitHash;
-
-    if (!gitWolfBranchId || !commitHash) {
-      throw new Error(
-        `Could not extract branch/commit info. Got keys: ${Object.keys(data || {}).join(', ')}`,
-      );
-    }
+    ({ branchId, commitHash, filesData } = await fetchGitContext({
+      trpcBase,
+      authHeader,
+      environmentId,
+    }));
   } catch (err) {
     console.error('Error fetching environment files:', err);
     if (err instanceof QawAuthError) {
@@ -181,77 +511,180 @@ router.post('/generate', async (req, res) => {
     return res.status(502).json({ error: `Failed to fetch environment info: ${err.message}` });
   }
 
-  // 3. Fetch raw file contents
-  let fileSource;
+  // 3. Generate the doc
   try {
-    const contentsUrl = `${trpcBase}/gitwolf.getFileContents?input=${encodeURIComponent(JSON.stringify({ json: { branchId: gitWolfBranchId, commitHash, path: relativePath } }))}`;
-    const contentsRes = await fetch(contentsUrl, { headers: authHeader });
-    const rawText = await contentsRes.text();
-
-    if (contentsRes.status === 401 || contentsRes.status === 403) {
-      throw new QawAuthError();
-    }
-
-    if (!contentsRes.ok) {
-      throw new Error(`QA Wolf API returned ${contentsRes.status}: ${rawText.slice(0, 300)}`);
-    }
-
-    const contentsData = JSON.parse(rawText);
-    const data = contentsData?.result?.data?.json ?? contentsData?.result?.data ?? contentsData;
-    fileSource = data?.content;
-
-    if (typeof fileSource !== 'string') {
-      throw new Error(`Unexpected response shape. Got keys: ${Object.keys(data || {}).join(', ')}`);
-    }
+    const knownPaths = collectKnownPaths(filesData);
+    const doc = await generateFlowDoc({
+      trpcBase,
+      authHeader,
+      branchId,
+      commitHash,
+      relativePath,
+      orgSlug,
+      knownPaths,
+      includeHelpers: includeHelpers === true,
+    });
+    return res.json({ success: true, ...doc });
   } catch (err) {
-    console.error('Error fetching file contents:', err);
+    console.error('Error generating flow doc:', err);
     if (err instanceof QawAuthError) {
       return res.status(401).json({ error: err.message });
     }
     return res.status(502).json({ error: `Failed to fetch flow file: ${err.message}` });
   }
+});
 
-  // 4. Extract test steps
-  const steps = extractTestSteps(fileSource);
+// POST /api/flow-doc/list-flows
+// Returns the list of flows in an environment WITHOUT generating any docs, so
+// the user can choose which ones to generate.
+router.post('/list-flows', async (req, res) => {
+  const { environmentUrl } = req.body;
 
-  // 5. Generate AI summary via Anthropic
-  let summary;
-  try {
-    const systemPrompt =
-      'You are a senior QA engineer writing professional technical documentation for a sales leave-behind document. ' +
-      'Your response must be exactly 2 - 4 sentences, no more. ' +
-      'Never use em dashes. Use plain punctuation only.';
-
-    const userPrompt =
-      `Summarize what the following QA Wolf automated test flow verifies end-to-end in exactly 2 - 4 sentences. ` +
-      `Be specific about the features and user actions covered. Stop after the second sentence.\n\n` +
-      `Flow file path: ${relativePath}\n\n` +
-      `Flow source code:\n${fileSource}`;
-
-    summary = await anthropicService.callAnthropic(systemPrompt, userPrompt);
-
-    // Hard-enforce 2 sentences: split on ". " or "." followed by capital or end-of-string
-    // Use a positive lookahead so we split after the period, not before the next word
-    const sentenceParts = summary.split(/(?<=[.!?])\s+(?=[A-Z])/);
-    if (sentenceParts.length > 2) {
-      summary = sentenceParts.slice(0, 2).join(' ').trim();
-    }
-  } catch (err) {
-    console.error('Error generating summary:', err);
-    // Non-fatal: return a placeholder so the doc is still useful
-    summary = 'AI summary unavailable. Please review the flow steps below.';
+  if (!environmentUrl || typeof environmentUrl !== 'string') {
+    return res.status(400).json({ error: 'environmentUrl is required.' });
   }
 
-  const flowName = flowNameFromPath(relativePath);
-  const orgName = orgNameFromSlug(orgSlug);
-  const docTitle = orgName ? `${orgName} - ${flowName}` : flowName;
+  const qawBearerToken = process.env.QAW_BEARER_TOKEN;
+  if (!qawBearerToken) {
+    return res.status(500).json({ error: 'QAW_BEARER_TOKEN is not configured on the server.' });
+  }
+
+  let environmentId, trpcBase, orgSlug;
+  try {
+    ({ environmentId, trpcBase, orgSlug } = parseQawolfUrl(environmentUrl));
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+
+  const authHeader = { Authorization: `Bearer ${qawBearerToken}` };
+
+  let filesData;
+  try {
+    ({ filesData } = await fetchGitContext({ trpcBase, authHeader, environmentId }));
+  } catch (err) {
+    console.error('Error fetching environment files:', err);
+    if (err instanceof QawAuthError) {
+      return res.status(401).json({ error: err.message });
+    }
+    return res.status(502).json({ error: `Failed to fetch environment info: ${err.message}` });
+  }
+
+  const flowPaths = enumerateFlowFiles(filesData);
+  if (flowPaths.length === 0) {
+    return res.status(404).json({
+      error: 'No flow files (*.flow.js) were found in this environment.',
+    });
+  }
+
+  const flows = flowPaths.map((filePath) => ({
+    filePath,
+    flowName: flowNameFromPath(filePath),
+  }));
 
   return res.json({
     success: true,
-    flowName: docTitle,
-    filePath: relativePath,
-    summary,
-    steps,
+    environmentName: orgNameFromSlug(orgSlug),
+    flows,
+  });
+});
+
+// POST /api/flow-doc/generate-bulk
+router.post('/generate-bulk', async (req, res) => {
+  const { environmentUrl, filePaths, includeHelpers } = req.body;
+
+  if (!environmentUrl || typeof environmentUrl !== 'string') {
+    return res.status(400).json({ error: 'environmentUrl is required.' });
+  }
+
+  const qawBearerToken = process.env.QAW_BEARER_TOKEN;
+  if (!qawBearerToken) {
+    return res.status(500).json({ error: 'QAW_BEARER_TOKEN is not configured on the server.' });
+  }
+
+  // 1. Parse URL (file param is ignored for bulk)
+  let environmentId, trpcBase, orgSlug;
+  try {
+    ({ environmentId, trpcBase, orgSlug } = parseQawolfUrl(environmentUrl));
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+
+  const authHeader = { Authorization: `Bearer ${qawBearerToken}` };
+
+  // 2. Resolve git context + file tree
+  let branchId, commitHash, filesData;
+  try {
+    ({ branchId, commitHash, filesData } = await fetchGitContext({
+      trpcBase,
+      authHeader,
+      environmentId,
+    }));
+  } catch (err) {
+    console.error('Error fetching environment files:', err);
+    if (err instanceof QawAuthError) {
+      return res.status(401).json({ error: err.message });
+    }
+    return res.status(502).json({ error: `Failed to fetch environment info: ${err.message}` });
+  }
+
+  // 3. Enumerate flow files
+  const flowPaths = enumerateFlowFiles(filesData);
+  if (flowPaths.length === 0) {
+    return res.status(404).json({
+      error: 'No flow files (*.flow.js) were found in this environment.',
+    });
+  }
+
+  // Restrict to the user-selected flows. If none are provided we fall back to
+  // all flows (backwards compatible), but the UI always sends a selection.
+  let targetPaths = flowPaths;
+  if (Array.isArray(filePaths) && filePaths.length > 0) {
+    const allowed = new Set(flowPaths);
+    targetPaths = filePaths.filter((p) => allowed.has(p));
+    if (targetPaths.length === 0) {
+      return res.status(400).json({
+        error: 'None of the selected flows were found in this environment.',
+      });
+    }
+  }
+
+  const knownPaths = collectKnownPaths(filesData);
+
+  // 4. Generate a doc per flow with bounded concurrency; capture per-flow failures
+  const failures = [];
+  let authFailed = false;
+
+  const docs = await mapWithConcurrency(targetPaths, 4, async (relativePath) => {
+    try {
+      return await generateFlowDoc({
+        trpcBase,
+        authHeader,
+        branchId,
+        commitHash,
+        relativePath,
+        orgSlug,
+        knownPaths,
+        includeHelpers: includeHelpers === true,
+      });
+    } catch (err) {
+      if (err instanceof QawAuthError) authFailed = true;
+      failures.push({ filePath: relativePath, error: err.message });
+      return null;
+    }
+  });
+
+  const successfulDocs = docs.filter(Boolean);
+
+  // If everything failed on auth, surface the actionable 401.
+  if (successfulDocs.length === 0 && authFailed) {
+    return res.status(401).json({ error: QAW_INVALID_TOKEN_MESSAGE });
+  }
+
+  return res.json({
+    success: true,
+    environmentName: orgNameFromSlug(orgSlug),
+    docs: successfulDocs,
+    failures,
   });
 });
 
@@ -260,9 +693,11 @@ router.get('/', (_req, res) => {
   res.json({
     project: 'Flow Doc Generator',
     description: 'Generate technical leave-behind documents from QA Wolf flow URLs',
-    version: '1.0.0',
+    version: '2.0.0',
     endpoints: {
       generate: 'POST /api/flow-doc/generate',
+      listFlows: 'POST /api/flow-doc/list-flows',
+      generateBulk: 'POST /api/flow-doc/generate-bulk',
     },
   });
 });

--- a/frontend/src/projects/flow-doc-generator/FlowDocGenerator.css
+++ b/frontend/src/projects/flow-doc-generator/FlowDocGenerator.css
@@ -257,6 +257,31 @@
   color: rgba(255, 255, 255, 0.5);
 }
 
+.fdg-helpers-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.85rem;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+  user-select: none;
+  flex-wrap: wrap;
+}
+
+.fdg-helpers-toggle input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--coral);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.fdg-helpers-hint {
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 0.75rem;
+}
+
 /* =========================
  * Loading + error states
  * ========================= */
@@ -606,4 +631,327 @@
   background: #ecfdf5;
   color: #065f46;
   border-color: #6ee7b7;
+}
+
+/* =========================
+ * Helper files section — lives inside the paper preview, mirrors the
+ * steps section but labels each block with its repo path instead of a
+ * numbered step pill.
+ * ========================= */
+
+.fdg-helpers-section {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.fdg-helper-path {
+  font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', Menlo, monospace;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: #3d3df5;
+  word-break: break-all;
+}
+
+/* =========================
+ * Bulk results — list of doc cards + per-flow failure summary
+ * ========================= */
+
+.fdg-doc-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.fdg-doc-count {
+  margin: 0;
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.fdg-warning {
+  padding: 0.85rem 1.1rem;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-left: 3px solid #f59e0b;
+  border-radius: 0.6rem;
+  color: #fde68a;
+  font-size: 0.875rem;
+}
+
+.fdg-failure-list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  line-height: 1.5;
+}
+
+.fdg-failure-list li {
+  word-break: break-word;
+}
+
+/* =========================
+ * Flow selection panel — shown for environment URLs so the user picks
+ * which flows to generate instead of generating all of them.
+ * ========================= */
+
+.fdg-select-panel {
+  background: var(--midnight-navy);
+  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.85rem;
+  padding: 1.1rem 1.3rem;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    0 12px 24px -18px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.fdg-select-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.fdg-select-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--white);
+}
+
+.fdg-select-subtitle {
+  margin: 0.2rem 0 0;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.fdg-select-toolbar {
+  display: flex;
+  gap: 0.65rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.fdg-filter-input {
+  flex: 1;
+  min-width: 12rem;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.8125rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.5rem;
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--white);
+  outline: none;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.fdg-filter-input:focus {
+  border-color: var(--coral);
+  box-shadow: 0 0 0 2px rgba(255, 107, 74, 0.25);
+}
+
+.fdg-filter-input::placeholder {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.fdg-text-btn {
+  padding: 0.5rem 0.85rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.5rem;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.fdg-text-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+
+.fdg-flow-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  max-height: 22rem;
+  overflow-y: auto;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.6rem;
+}
+
+.fdg-flow-item {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.75rem;
+  cursor: pointer;
+  border-radius: 0.4rem;
+  transition: background-color 0.12s ease;
+}
+
+.fdg-flow-item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.fdg-flow-item input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  accent-color: var(--coral);
+  cursor: pointer;
+}
+
+.fdg-flow-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--white);
+  flex-shrink: 0;
+}
+
+.fdg-flow-path {
+  font-family: 'SFMono-Regular', 'Consolas', Menlo, monospace;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.45);
+  margin-left: auto;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fdg-flow-empty {
+  padding: 0.85rem 0.75rem;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.5);
+  text-align: center;
+}
+
+.fdg-select-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+/* =========================
+ * Save-to-Opp modal
+ * ========================= */
+
+.fdg-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.fdg-modal-card {
+  width: 100%;
+  max-width: 26rem;
+  background: var(--midnight-navy);
+  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.85rem;
+  padding: 1.25rem 1.4rem;
+  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.75);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.fdg-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.fdg-modal-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--white);
+}
+
+.fdg-modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+  padding: 0.25rem;
+  line-height: 1;
+  transition: color 0.15s ease;
+}
+
+.fdg-modal-close:hover:not(:disabled) {
+  color: var(--white);
+}
+
+.fdg-modal-subtitle {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.6);
+  line-height: 1.5;
+}
+
+.fdg-modal-empty {
+  margin: 0;
+  padding: 0.85rem;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.55rem;
+  text-align: center;
+}
+
+.fdg-opp-select {
+  width: 100%;
+  padding: 0.6rem 0.85rem;
+  font-size: 0.875rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.55rem;
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--white);
+  outline: none;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.fdg-opp-select:focus {
+  border-color: var(--coral);
+  box-shadow: 0 0 0 2px rgba(255, 107, 74, 0.25);
+}
+
+.fdg-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.65rem;
+  margin-top: 0.25rem;
 }

--- a/frontend/src/projects/flow-doc-generator/index.jsx
+++ b/frontend/src/projects/flow-doc-generator/index.jsx
@@ -1,7 +1,23 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import './FlowDocGenerator.css';
+import { listMyOpps, getOpp, updateOpp } from '../../services/api';
+import { useToast } from '../../contexts/ToastContext';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+
+// Build a single-flow QA Wolf IDE URL from the demo environment URL and a flow
+// file path, e.g. ".../automate/ide?file=src%2Fflows%2Ffoo.flow.ts". This is
+// the same shape the Howl Sheet parses, so the saved Opp flow link is valid.
+function buildFlowFileUrl(envUrl, filePath) {
+  try {
+    const u = new URL(envUrl);
+    u.search = '';
+    u.searchParams.set('file', filePath);
+    return u.toString();
+  } catch {
+    return envUrl;
+  }
+}
 
 // Auto-resizing textarea for inline editing
 function EditableTextarea({ value, onChange, className }) {
@@ -52,6 +68,7 @@ function DocOutput({ doc }) {
   const [summary, setSummary] = useState(doc.summary);
   const [steps, setSteps] = useState(doc.steps);
   const [showPrintTip, setShowPrintTip] = useState(false);
+  const helpers = doc.helpers || [];
 
   const handleStepNameChange = useCallback((index, newName) => {
     setSteps((prev) => prev.map((s, i) => (i === index ? { ...s, name: newName } : s)));
@@ -100,6 +117,23 @@ function DocOutput({ doc }) {
   </div>`,
     )
     .join('')}
+  ${
+    helpers.length > 0
+      ? `
+  <div class="fdg-summary-block">
+    <h2 class="fdg-section-heading">Helper Files</h2>
+  </div>
+  ${helpers
+    .map(
+      (helper) => `
+  <div class="fdg-step">
+    <h3 class="fdg-step-name-heading">${helper.path}</h3>
+    <pre>${helper.code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>
+  </div>`,
+    )
+    .join('')}`
+      : ''
+  }
 </body>
 </html>`;
 
@@ -185,33 +219,97 @@ function DocOutput({ doc }) {
             <TestStep key={`step-${i}`} step={step} index={i} onNameChange={handleStepNameChange} />
           ))}
         </section>
+
+        {helpers.length > 0 && (
+          <section className="fdg-helpers-section">
+            <h3 className="fdg-section-heading">Helper Files</h3>
+            {helpers.map((helper, i) => (
+              <div className="fdg-step" key={`helper-${i}`}>
+                <h4 className="fdg-step-name-heading">
+                  <span className="fdg-helper-path">{helper.path}</span>
+                </h4>
+                <div className="fdg-code-wrapper">
+                  <pre className="fdg-code-block">
+                    <code>{helper.code}</code>
+                  </pre>
+                </div>
+              </div>
+            ))}
+          </section>
+        )}
       </div>
     </div>
   );
 }
 
+// A URL that points at a specific flow file has a ?file= query param; an
+// environment URL (no file) triggers bulk generation for every flow.
+function isEnvironmentUrl(url) {
+  try {
+    return !new URL(url).searchParams.get('file');
+  } catch {
+    return false;
+  }
+}
+
+function authHeaders() {
+  const token = localStorage.getItem('authToken');
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
 function FlowDocGenerator() {
+  const toast = useToast();
   const [flowUrl, setFlowUrl] = useState('');
+  const [includeHelpers, setIncludeHelpers] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [generating, setGenerating] = useState(false);
   const [error, setError] = useState(null);
-  const [doc, setDoc] = useState(null);
+  const [docs, setDocs] = useState([]);
+  const [failures, setFailures] = useState([]);
+
+  // Bulk selection state: the flows found in the environment, the user's
+  // selection, and a filter for narrowing down long lists.
+  const [flowOptions, setFlowOptions] = useState([]);
+  const [selectedPaths, setSelectedPaths] = useState(() => new Set());
+  const [filter, setFilter] = useState('');
+
+  // "Save to Opp" modal state.
+  const [oppModalOpen, setOppModalOpen] = useState(false);
+  const [oppList, setOppList] = useState([]);
+  const [oppLoading, setOppLoading] = useState(false);
+  const [selectedOppId, setSelectedOppId] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const resetResults = () => {
+    setError(null);
+    setDocs([]);
+    setFailures([]);
+    setFlowOptions([]);
+    setSelectedPaths(new Set());
+    setFilter('');
+  };
 
   const handleGenerate = useCallback(async () => {
-    if (!flowUrl.trim()) return;
+    const trimmed = flowUrl.trim();
+    if (!trimmed) return;
 
     setLoading(true);
-    setError(null);
-    setDoc(null);
+    resetResults();
+
+    const bulk = isEnvironmentUrl(trimmed);
 
     try {
-      const token = localStorage.getItem('authToken');
-      const headers = { 'Content-Type': 'application/json' };
-      if (token) headers['Authorization'] = `Bearer ${token}`;
+      // Environment URL: fetch the flow list first so the user can choose
+      // which flows to generate (instead of generating all of them).
+      const endpoint = bulk ? '/flow-doc/list-flows' : '/flow-doc/generate';
+      const body = bulk ? { environmentUrl: trimmed } : { flowUrl: trimmed, includeHelpers };
 
-      const res = await fetch(`${API_BASE_URL}/flow-doc/generate`, {
+      const res = await fetch(`${API_BASE_URL}${endpoint}`, {
         method: 'POST',
-        headers,
-        body: JSON.stringify({ flowUrl: flowUrl.trim() }),
+        headers: authHeaders(),
+        body: JSON.stringify(body),
       });
 
       const data = await res.json();
@@ -220,13 +318,137 @@ function FlowDocGenerator() {
         throw new Error(data.error || `Server error ${res.status}`);
       }
 
-      setDoc(data);
+      if (bulk) {
+        setFlowOptions(data.flows || []);
+      } else {
+        setDocs([data]);
+      }
     } catch (err) {
       setError(err.message || 'An unexpected error occurred.');
     } finally {
       setLoading(false);
     }
-  }, [flowUrl]);
+  }, [flowUrl, includeHelpers]);
+
+  const togglePath = useCallback((filePath) => {
+    setSelectedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(filePath)) next.delete(filePath);
+      else next.add(filePath);
+      return next;
+    });
+  }, []);
+
+  const filteredOptions = flowOptions.filter((f) => {
+    if (!filter.trim()) return true;
+    const q = filter.trim().toLowerCase();
+    return f.flowName.toLowerCase().includes(q) || f.filePath.toLowerCase().includes(q);
+  });
+
+  const selectAllFiltered = useCallback(() => {
+    setSelectedPaths((prev) => {
+      const next = new Set(prev);
+      filteredOptions.forEach((f) => next.add(f.filePath));
+      return next;
+    });
+  }, [filteredOptions]);
+
+  const clearSelection = useCallback(() => setSelectedPaths(new Set()), []);
+
+  const handleGenerateSelected = useCallback(async () => {
+    if (selectedPaths.size === 0) return;
+
+    setGenerating(true);
+    setError(null);
+    setDocs([]);
+    setFailures([]);
+
+    try {
+      const res = await fetch(`${API_BASE_URL}/flow-doc/generate-bulk`, {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({
+          environmentUrl: flowUrl.trim(),
+          filePaths: [...selectedPaths],
+          includeHelpers,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error || `Server error ${res.status}`);
+      }
+
+      setDocs(data.docs || []);
+      setFailures(data.failures || []);
+    } catch (err) {
+      setError(err.message || 'An unexpected error occurred.');
+    } finally {
+      setGenerating(false);
+    }
+  }, [flowUrl, selectedPaths, includeHelpers]);
+
+  const openOppModal = useCallback(async () => {
+    if (selectedPaths.size === 0) return;
+    setOppModalOpen(true);
+    setSelectedOppId('');
+    setOppLoading(true);
+    try {
+      const data = await listMyOpps();
+      setOppList(data?.saved || []);
+    } catch (err) {
+      toast.error(err.message || 'Failed to load your Opps.');
+      setOppList([]);
+    } finally {
+      setOppLoading(false);
+    }
+  }, [selectedPaths, toast]);
+
+  const handleSaveToOpp = useCallback(async () => {
+    if (!selectedOppId) return;
+
+    setSaving(true);
+    try {
+      const opp = await getOpp(selectedOppId);
+      const existing = opp?.creation || { demoWorkspaceUrl: '', flows: [] };
+      const existingFlows = existing.flows || [];
+      const existingUrls = new Set(existingFlows.map((f) => f.url));
+
+      const envUrl = flowUrl.trim();
+      const byPath = new Map(flowOptions.map((f) => [f.filePath, f]));
+      const newFlows = [...selectedPaths]
+        .map((filePath, i) => {
+          const opt = byPath.get(filePath);
+          return {
+            id: `flow-${Date.now()}-${i}`,
+            name: opt?.flowName || filePath,
+            url: buildFlowFileUrl(envUrl, filePath),
+          };
+        })
+        .filter((f) => !existingUrls.has(f.url));
+
+      const merged = {
+        ...existing,
+        demoWorkspaceUrl: existing.demoWorkspaceUrl || envUrl,
+        flows: [...existingFlows, ...newFlows],
+      };
+
+      await updateOpp(selectedOppId, { creation: merged });
+
+      const skipped = selectedPaths.size - newFlows.length;
+      const oppName = oppList.find((o) => o.id === selectedOppId)?.oppName || 'Opp';
+      toast.success(
+        `Added ${newFlows.length} flow${newFlows.length === 1 ? '' : 's'} to ${oppName}` +
+          (skipped > 0 ? ` (${skipped} already linked)` : ''),
+      );
+      setOppModalOpen(false);
+    } catch (err) {
+      toast.error(err.message || 'Failed to save flows to the Opp.');
+    } finally {
+      setSaving(false);
+    }
+  }, [selectedOppId, flowUrl, flowOptions, selectedPaths, oppList, toast]);
 
   const handleKeyDown = useCallback(
     (e) => {
@@ -239,7 +461,10 @@ function FlowDocGenerator() {
     <div className="flow-doc-generator">
       <div className="fdg-header">
         <h1>Flow Doc Generator</h1>
-        <p>Paste a QA Wolf flow URL to generate a formatted technical leave-behind document.</p>
+        <p>
+          Paste a single QA Wolf flow URL for one document, or an environment URL to bulk-generate a
+          document for every flow in that environment.
+        </p>
       </div>
 
       <div className="fdg-info-panels">
@@ -247,14 +472,15 @@ function FlowDocGenerator() {
           <p className="fdg-how-title">How it works</p>
           <ol className="fdg-how-steps">
             <li>
-              Paste a QA Wolf flow URL and click <strong>Generate</strong>
+              Paste a flow URL (single doc) or an environment URL (one doc per flow) and click{' '}
+              <strong>Generate</strong>
             </li>
-            <li>The AI will summarize the flow and extract each test step</li>
+            <li>The AI summarizes each flow, extracts its test steps, and pulls in helper files</li>
             <li>
               Click any field — title, summary, or step names — to edit them before downloading
             </li>
             <li>
-              Hit <strong>Download PDF</strong> to save a branded leave-behind
+              Hit <strong>Download PDF</strong> on any document to save a branded leave-behind
             </li>
           </ol>
         </div>
@@ -264,7 +490,7 @@ function FlowDocGenerator() {
           <ul className="fdg-gotchas-list">
             <li>The SE Lead must be invited to the customer&apos;s QA Wolf team</li>
             <li>Must use a production URL — staging URLs are not supported</li>
-            <li>Step extraction uses Helpers (V2 coming soon)</li>
+            <li>Bulk generation over large environments can take a little while</li>
             <li>
               When saving the PDF, uncheck <strong>Headers and Footers</strong> in the print dialog
             </li>
@@ -274,14 +500,14 @@ function FlowDocGenerator() {
 
       <div className="fdg-input-section">
         <label className="fdg-input-label" htmlFor="fdg-url-input">
-          QA Wolf Flow URL
+          QA Wolf Flow or Environment URL
         </label>
         <div className="fdg-input-row">
           <input
             id="fdg-url-input"
             type="url"
             className="fdg-url-input"
-            placeholder="https://app.qawolf.com/org/environments/ENV_ID/automate/ide?file=src%2Fflows%2F..."
+            placeholder="https://app.qawolf.com/org/environments/ENV_ID/automate/ide (add ?file=... for a single flow)"
             value={flowUrl}
             onChange={(e) => setFlowUrl(e.target.value)}
             onKeyDown={handleKeyDown}
@@ -296,18 +522,208 @@ function FlowDocGenerator() {
             {loading ? 'Generating...' : 'Generate'}
           </button>
         </div>
+
+        <label className="fdg-helpers-toggle">
+          <input
+            type="checkbox"
+            checked={includeHelpers}
+            onChange={(e) => setIncludeHelpers(e.target.checked)}
+            disabled={loading}
+          />
+          <span>Include helper files</span>
+          <span className="fdg-helpers-hint">
+            Pulls in utility/helper files imported by the flow. Leave off for a cleaner doc.
+          </span>
+        </label>
       </div>
 
       {loading && (
         <div className="fdg-loading">
           <span className="fdg-spinner" />
-          Fetching flow and generating document...
+          Fetching flows...
+        </div>
+      )}
+
+      {generating && (
+        <div className="fdg-loading">
+          <span className="fdg-spinner" />
+          Generating {selectedPaths.size} document{selectedPaths.size === 1 ? '' : 's'}...
         </div>
       )}
 
       {error && <div className="fdg-error">{error}</div>}
 
-      {doc && !loading && <DocOutput doc={doc} />}
+      {!loading && flowOptions.length > 0 && (
+        <div className="fdg-select-panel">
+          <div className="fdg-select-header">
+            <div>
+              <p className="fdg-select-title">
+                Found {flowOptions.length} flow{flowOptions.length === 1 ? '' : 's'}
+              </p>
+              <p className="fdg-select-subtitle">
+                Select the flows you want to generate documents for.
+              </p>
+            </div>
+            <div className="fdg-select-actions">
+              <button
+                type="button"
+                className="fdg-text-btn"
+                onClick={openOppModal}
+                disabled={selectedPaths.size === 0}
+              >
+                Save to Opp
+              </button>
+              <button
+                type="button"
+                className="fdg-generate-btn"
+                onClick={handleGenerateSelected}
+                disabled={generating || selectedPaths.size === 0}
+              >
+                {generating ? 'Generating...' : `Generate ${selectedPaths.size} Selected`}
+              </button>
+            </div>
+          </div>
+
+          <div className="fdg-select-toolbar">
+            <input
+              type="text"
+              className="fdg-filter-input"
+              placeholder="Filter flows..."
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+            />
+            <button type="button" className="fdg-text-btn" onClick={selectAllFiltered}>
+              Select all{filter.trim() ? ' (filtered)' : ''}
+            </button>
+            <button type="button" className="fdg-text-btn" onClick={clearSelection}>
+              Clear
+            </button>
+          </div>
+
+          <ul className="fdg-flow-list">
+            {filteredOptions.map((f) => (
+              <li key={f.filePath}>
+                <label className="fdg-flow-item">
+                  <input
+                    type="checkbox"
+                    checked={selectedPaths.has(f.filePath)}
+                    onChange={() => togglePath(f.filePath)}
+                  />
+                  <span className="fdg-flow-name">{f.flowName}</span>
+                  <span className="fdg-flow-path">{f.filePath}</span>
+                </label>
+              </li>
+            ))}
+            {filteredOptions.length === 0 && (
+              <li className="fdg-flow-empty">No flows match &quot;{filter}&quot;</li>
+            )}
+          </ul>
+        </div>
+      )}
+
+      {!loading && failures.length > 0 && (
+        <div className="fdg-warning">
+          {failures.length} flow{failures.length === 1 ? '' : 's'} could not be generated:
+          <ul className="fdg-failure-list">
+            {failures.map((f, i) => (
+              <li key={`failure-${i}`}>
+                {f.filePath} — {f.error}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {!loading && docs.length > 0 && (
+        <div className="fdg-doc-list">
+          {docs.length > 1 && (
+            <p className="fdg-doc-count">
+              Generated {docs.length} documents. Edit and download each individually below.
+            </p>
+          )}
+          {docs.map((doc, i) => (
+            <DocOutput key={doc.filePath || `doc-${i}`} doc={doc} />
+          ))}
+        </div>
+      )}
+
+      {oppModalOpen && (
+        <div
+          className="fdg-modal-overlay"
+          onClick={() => !saving && setOppModalOpen(false)}
+          role="presentation"
+        >
+          <div
+            className="fdg-modal-card"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Save flows to an Opp"
+          >
+            <div className="fdg-modal-header">
+              <h3 className="fdg-modal-title">Save to Opp</h3>
+              <button
+                type="button"
+                className="fdg-modal-close"
+                onClick={() => setOppModalOpen(false)}
+                disabled={saving}
+                aria-label="Close"
+              >
+                &#10005;
+              </button>
+            </div>
+
+            <p className="fdg-modal-subtitle">
+              Adds {selectedPaths.size} selected flow{selectedPaths.size === 1 ? '' : 's'} and the
+              demo URL to the Opportunity&apos;s Creation section.
+            </p>
+
+            {oppLoading ? (
+              <div className="fdg-loading">
+                <span className="fdg-spinner" />
+                Loading your Opps...
+              </div>
+            ) : oppList.length === 0 ? (
+              <p className="fdg-modal-empty">
+                No saved Opps yet — create one on the Hunt Board first.
+              </p>
+            ) : (
+              <select
+                className="fdg-opp-select"
+                value={selectedOppId}
+                onChange={(e) => setSelectedOppId(e.target.value)}
+                disabled={saving}
+              >
+                <option value="">Select an Opp…</option>
+                {oppList.map((o) => (
+                  <option key={o.id} value={o.id}>
+                    {o.oppName}
+                  </option>
+                ))}
+              </select>
+            )}
+
+            <div className="fdg-modal-actions">
+              <button
+                type="button"
+                className="fdg-text-btn"
+                onClick={() => setOppModalOpen(false)}
+                disabled={saving}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="fdg-generate-btn"
+                onClick={handleSaveToOpp}
+                disabled={saving || !selectedOppId}
+              >
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/projects/opps/OppDetail.jsx
+++ b/frontend/src/projects/opps/OppDetail.jsx
@@ -699,11 +699,22 @@ function OppDetail() {
             )}
           </div>
           <div className="opp-properties" style={{ gridTemplateColumns: '1fr' }}>
+            <div className="opp-property">
+              <span className="opp-property__label">Demo URL</span>
+              <EditableField
+                value={creation.demoWorkspaceUrl}
+                editable={canEdit}
+                placeholder="https://app.qawolf.com/…"
+                type="url"
+                onSave={(v) => patchCreation({ demoWorkspaceUrl: v })}
+                onStatusChange={onSaveStatus}
+              />
+            </div>
             {['url', 'vpn', 'user', 'integrations'].map((key) => {
               const labels = {
                 url: 'URL / APK / IPA',
                 vpn: 'Any VPN',
-                user: 'User',
+                user: 'Credentials',
                 integrations: 'Integrations',
               };
               return (
@@ -747,19 +758,6 @@ function OppDetail() {
                 Slack thread ↗
               </a>
             )}
-          </div>
-          <div className="opp-properties" style={{ gridTemplateColumns: '1fr' }}>
-            <div className="opp-property">
-              <span className="opp-property__label">Demo Workspace URL</span>
-              <EditableField
-                value={creation.demoWorkspaceUrl}
-                editable={canEdit}
-                placeholder="https://app.qawolf.com/…"
-                type="url"
-                onSave={(v) => patchCreation({ demoWorkspaceUrl: v })}
-                onStatusChange={onSaveStatus}
-              />
-            </div>
           </div>
           <div className="opp-flows">
             <div className="opp-flows__header">


### PR DESCRIPTION
## Summary
- **Bulk generation from an environment URL.** Paste a QA Wolf environment URL into the Howl Sheet (Flow Doc Generator) and it lists every flow, lets you filter and select which ones to generate (nothing selected by default), then generates one editable, individually-downloadable doc per selected flow. Single-flow URLs (`?file=...`) still generate immediately.
- **Helper files (opt-in).** A new "Include helper files" toggle pulls the flow's helper/utility files into the generated doc and AI summary. Import resolution handles relative (`../utilities/foo`) and baseUrl-style (`utilities/foo`) imports, matched against the environment's real file tree (lands on `src/utilities/*`).
- **Save to Opp.** From the selection panel, "Save to Opp" writes the demo URL + selected flows into an existing Opportunity's Creation section (append, skip duplicates, set the demo URL only if empty). Uses existing `listMyOpps` / `getOpp` / `updateOpp` APIs — no backend changes to the opps routes.
- **Demo URL relocated.** Moved the Demo URL field from the Creation section into Technical Specs, and relabeled the Tech Specs "User" field to "Credentials". Storage is unchanged (`creation.demoWorkspaceUrl`), so no migration.

## Implementation notes
- Backend ([backend/src/projects/flow-doc-generator/routes/index.js](backend/src/projects/flow-doc-generator/routes/index.js)): refactored the single-flow pipeline into a reusable `generateFlowDoc`; added `POST /list-flows` and `POST /generate-bulk` (bounded concurrency, per-flow failure capture); tree-walking flow enumeration + helper resolution that are defensive about the `gitwolf.getFiles` response shape.
- Frontend: selection UI, helper toggle, and the Save-to-Opp modal live in [frontend/src/projects/flow-doc-generator/index.jsx](frontend/src/projects/flow-doc-generator/index.jsx).

## Test plan
- [ ] Single flow URL (`?file=...`) generates one doc as before
- [ ] Environment URL lists flows; filter + select-all + clear work; only selected flows generate
- [ ] "Include helper files" pulls in `src/utilities/*` referenced by a flow
- [ ] "Save to Opp" appends selected flows (skips dupes) and sets demo URL when empty; verify on the Opp page
- [ ] Demo URL now appears under Technical Specs; "Credentials" field renders

Made with [Cursor](https://cursor.com)