### PR TITLE
ci: emit build/lint/test checks required by branch ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,35 +7,64 @@ on:
     branches: [main]
 
 jobs:
-  lint-and-format:
-    name: Lint & Format Check
+  # Job names below (lint / build / test) are intentionally lowercase so the
+  # emitted check contexts match the repository ruleset's required checks.
+  # Renaming a job changes its required-check context -- keep them in lockstep
+  # with the "Protect default branch" ruleset.
+
+  lint:
+    name: lint
     runs-on: ubuntu-latest
-
     steps:
-      # 1) Checkout repo
       - uses: actions/checkout@v4
-
-      # 2) Use the Node version pinned in package.json `engines`. The repo
-      #    runs engine-strict, so `npm ci` hard-fails (EBADENGINE) on any
-      #    other version -- keep this in lockstep with `engines.node`.
+      # Use the Node version pinned in package.json `engines`. The repo runs
+      # engine-strict, so `npm ci` hard-fails (EBADENGINE) on any other version.
       - uses: actions/setup-node@v4
         with:
           node-version: 24.16.0
           cache: npm
-
-      # 3) Install deps (respects workspaces)
       - run: npm ci
-
-      # 4) Lint (ESLint flat config)
       - run: npm run lint
-
-      # 5) Prettier formatting check (non-destructive)
+      # Prettier formatting check (non-destructive)
       - run: npm run format:check
 
-  # Prisma schema drift guard. Runs independently (no deps, just Node)
-  # so it catches dev (SQLite) vs prod (PostgreSQL) schema divergence
-  # even while other checks are red. Drift here means a feature can work
-  # locally and silently break in production.
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.16.0
+          cache: npm
+      # Workspaces aren't declared, so install root + frontend deps explicitly
+      # before building the frontend bundle.
+      - run: npm ci
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run build
+        working-directory: frontend
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.16.0
+          cache: npm
+      - run: npm ci
+      # TODO: enable real tests once a test runner is wired up in frontend/backend.
+      # The frontend has no `test` script yet, so use a tolerant no-op here so the
+      # required `test` check can report success instead of hanging unreported.
+      - name: Run tests (placeholder)
+        run: echo "No tests configured yet."
+
+  # Prisma schema drift guard. Not a required check, but catches dev (SQLite)
+  # vs prod (PostgreSQL) schema divergence that would pass locally and break
+  # in production.
   schema-sync:
     name: Prisma Schema Sync
     runs-on: ubuntu-latest
@@ -45,22 +74,3 @@ jobs:
         with:
           node-version: 24.16.0
       - run: node scripts/check-schema-sync.js
-
-  # Optional: run tests across all workspaces when you add them
-  tests:
-    name: Workspace Tests
-    runs-on: ubuntu-latest
-    needs: lint-and-format
-    if: always() # run even if lint job fails? change to `success()` if you prefer
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24.16.0
-          cache: npm
-      - run: npm ci
-      # TODO: enable real tests once a test runner is wired up in frontend/backend.
-      # Workspaces aren't declared yet, so `npm -ws test --if-present` errors out;
-      # use a tolerant no-op here so the check doesn't always fail.
-      - name: Run tests (placeholder)
-        run: echo "No tests configured yet."


### PR DESCRIPTION
The "Protect default branch" ruleset requires status checks named build, lint, and test, but the workflow emitted "Lint & Format Check" / "Workspace Tests" / "Prisma Schema Sync" -- so build/lint/test stayed "Expected" forever and blocked every PR.

Rename jobs to lint/test, add a real build job (frontend vite build), and keep the Prisma schema drift guard as a non-required job. Test stays a tolerant no-op until a runner is wired up (frontend has no test script yet).