### PR TITLE
refactor(flow-doc): remove helper-file inclusion from Howl Sheet

### DIFF
--- a/backend/src/projects/flow-doc-generator/routes/index.js
+++ b/backend/src/projects/flow-doc-generator/routes/index.js
@@ -1,5 +1,4 @@
 import express from 'express';
-import path from 'path';
 import { anthropicService } from '../../../services/anthropicService.js';
 
 const router = express.Router();
@@ -127,106 +126,6 @@ function extractTestSteps(source) {
 }
 
 /**
- * Pull import/require specifiers out of flow source code so we can resolve them
- * to helper/utility files. QA Wolf flows reference utilities both relatively
- * (`../utilities/foo`) and via the tsconfig baseUrl (`utilities/foo`), so we
- * capture every specifier and let `resolveHelperPaths` decide which ones map to
- * real first-party files in the environment tree (node modules simply won't
- * match anything in the tree and get dropped there).
- */
-function extractImportPaths(source) {
-  const specifiers = new Set();
-
-  // import ... from '<spec>'  and  import '<spec>'
-  const importRegex = /import\s+(?:[^'"]*?\s+from\s+)?["']([^"']+)["']/g;
-  // require('<spec>')
-  const requireRegex = /require\(\s*["']([^"']+)["']\s*\)/g;
-
-  for (const regex of [importRegex, requireRegex]) {
-    let match;
-    while ((match = regex.exec(source)) !== null) {
-      specifiers.add(match[1]);
-    }
-  }
-
-  return [...specifiers];
-}
-
-const HELPER_EXTENSIONS = ['.ts', '.js', '.tsx', '.jsx', '.mjs', '.cjs'];
-const HELPER_EXT_RE = /\.(ts|js|tsx|jsx|mjs|cjs)$/;
-// Directories that hold first-party shared helpers in a QA Wolf repo.
-const HELPER_DIR_RE = /(^|\/)(utilities|helpers|lib)\//;
-
-function stripHelperExt(p) {
-  return p.replace(HELPER_EXT_RE, '');
-}
-
-/**
- * Given a base path (no extension assumed), return the first matching file in
- * the tree, trying the path as-is, with each helper extension, and as an
- * index file.
- */
-function matchInTree(base, knownPaths) {
-  if (HELPER_EXT_RE.test(base)) {
-    return knownPaths.has(base) ? base : null;
-  }
-  for (const ext of HELPER_EXTENSIONS) {
-    if (knownPaths.has(base + ext)) return base + ext;
-  }
-  for (const ext of HELPER_EXTENSIONS) {
-    if (knownPaths.has(`${base}/index${ext}`)) return `${base}/index${ext}`;
-  }
-  return null;
-}
-
-/**
- * Resolve import specifiers from a flow file into concrete repo paths, matched
- * against the environment's real file tree. Handles three import styles:
- *
- *   1. Relative:        "../utilities/foo"  -> resolved against the flow's dir
- *   2. baseUrl / alias: "utilities/foo"     -> tried as-is and under "src/"
- *   3. Last resort:     match the specifier's basename to a file living in a
- *      utilities/helpers/lib directory (covers odd alias configs).
- *
- * Only paths that actually exist in the tree are returned, so node modules and
- * bad guesses are dropped rather than triggering 404 fetches.
- */
-function resolveHelperPaths(relativePath, specifiers, knownPaths) {
-  const resolved = new Set();
-  if (!knownPaths || knownPaths.size === 0) return [];
-
-  const baseDir = path.posix.dirname(relativePath);
-  const knownArr = [...knownPaths];
-
-  for (const spec of specifiers) {
-    let match = null;
-
-    if (spec.startsWith('.')) {
-      // 1. Relative to the flow file.
-      match = matchInTree(path.posix.normalize(path.posix.join(baseDir, spec)), knownPaths);
-    } else {
-      // 2. baseUrl-style: try as-is, then under a "src/" root.
-      match =
-        matchInTree(spec, knownPaths) ||
-        matchInTree(path.posix.normalize(path.posix.join('src', spec)), knownPaths);
-    }
-
-    // 3. Fallback: match the basename to a file in a helper directory.
-    if (!match) {
-      const baseName = stripHelperExt(path.posix.basename(spec));
-      match =
-        knownArr.find(
-          (p) => HELPER_DIR_RE.test(p) && stripHelperExt(path.posix.basename(p)) === baseName,
-        ) || null;
-    }
-
-    if (match) resolved.add(match);
-  }
-
-  return [...resolved];
-}
-
-/**
  * Recursively collect every string leaf in an arbitrary JSON structure.
  * The gitwolf.getFiles response shape is not guaranteed, so we walk it
  * defensively and pull out anything that looks like a file path.
@@ -254,19 +153,6 @@ function enumerateFlowFiles(filesData) {
     if (/\.flow\.(js|ts)$/.test(s)) flows.add(s);
   }
   return [...flows].sort();
-}
-
-/**
- * Set of every path-like string in the file tree, used to resolve helper
- * import specifiers to the file that actually exists.
- */
-function collectKnownPaths(filesData) {
-  const strings = collectAllStrings(filesData);
-  const paths = new Set();
-  for (const s of strings) {
-    if (/\.[a-z0-9]+$/i.test(s) && s.includes('/')) paths.add(s);
-  }
-  return paths;
 }
 
 /**
@@ -301,7 +187,7 @@ async function fetchFileContents({ trpcBase, authHeader, branchId, commitHash, f
 
 /**
  * Resolve the git branch/commit context for an environment and return the raw
- * files payload so callers can also enumerate flows / resolve helpers.
+ * files payload so callers can also enumerate flows.
  * Throws QawAuthError on 401/403.
  */
 async function fetchGitContext({ trpcBase, authHeader, environmentId }) {
@@ -334,30 +220,21 @@ async function fetchGitContext({ trpcBase, authHeader, environmentId }) {
 }
 
 /**
- * Generate an AI summary of a flow, including helper file source for context.
+ * Generate an AI summary of a flow.
  * Non-fatal: returns a placeholder string if the AI call fails.
  */
-async function summarizeFlow({ relativePath, fileSource, helpers }) {
+async function summarizeFlow({ relativePath, fileSource }) {
   try {
     const systemPrompt =
       'You are a senior QA engineer writing professional technical documentation for a sales leave-behind document. ' +
       'Your response must be exactly 2 - 4 sentences, no more. ' +
       'Never use em dashes. Use plain punctuation only.';
 
-    let userPrompt =
+    const userPrompt =
       `Summarize what the following QA Wolf automated test flow verifies end-to-end in exactly 2 - 4 sentences. ` +
       `Be specific about the features and user actions covered. Stop after the second sentence.\n\n` +
       `Flow file path: ${relativePath}\n\n` +
       `Flow source code:\n${fileSource}`;
-
-    if (helpers && helpers.length > 0) {
-      const helperBlocks = helpers
-        .map((h) => `Helper file path: ${h.path}\n${h.code}`)
-        .join('\n\n');
-      userPrompt +=
-        `\n\nThe flow relies on the following helper files. Use them to understand shared logic, ` +
-        `but keep the summary focused on what the flow verifies:\n\n${helperBlocks}`;
-    }
 
     let summary = await anthropicService.callAnthropic(systemPrompt, userPrompt);
 
@@ -375,12 +252,12 @@ async function summarizeFlow({ relativePath, fileSource, helpers }) {
 }
 
 /**
- * Build a full flow doc (title, summary, steps, helpers) for a single flow file.
+ * Build a full flow doc (title, summary, steps) for a single flow file.
  * Reused by both the single-flow and bulk endpoints. Expects the caller to have
- * already resolved the git context (branchId/commitHash) and file tree.
+ * already resolved the git context (branchId/commitHash).
  *
- * Throws QawAuthError if fetching the main flow file fails auth (so the route
- * can return 401). Helper fetches are best-effort and never fail the doc.
+ * Throws QawAuthError if fetching the flow file fails auth (so the route
+ * can return 401).
  */
 async function generateFlowDoc({
   trpcBase,
@@ -389,10 +266,8 @@ async function generateFlowDoc({
   commitHash,
   relativePath,
   orgSlug,
-  knownPaths,
-  includeHelpers = false,
 }) {
-  // 1. Fetch the main flow file
+  // 1. Fetch the flow file
   const fileSource = await fetchFileContents({
     trpcBase,
     authHeader,
@@ -401,35 +276,11 @@ async function generateFlowDoc({
     filePath: relativePath,
   });
 
-  // 2. Optionally resolve + fetch helper files referenced via relative imports.
-  // Helpers are opt-in (best-effort): they're only useful for some flows, so we
-  // skip the extra fetches entirely unless the caller asks for them.
-  const helpers = [];
-  if (includeHelpers) {
-    const specifiers = extractImportPaths(fileSource);
-    const helperPaths = resolveHelperPaths(relativePath, specifiers, knownPaths);
-    for (const helperPath of helperPaths) {
-      try {
-        const code = await fetchFileContents({
-          trpcBase,
-          authHeader,
-          branchId,
-          commitHash,
-          filePath: helperPath,
-        });
-        helpers.push({ path: helperPath, code: code.trim() });
-      } catch (err) {
-        // Skip helpers we can't fetch (404, resolution miss, etc.) — non-fatal.
-        console.warn(`Skipping helper ${helperPath}: ${err.message}`);
-      }
-    }
-  }
-
-  // 3. Extract test steps
+  // 2. Extract test steps
   const steps = extractTestSteps(fileSource);
 
-  // 4. AI summary (includes helper context)
-  const summary = await summarizeFlow({ relativePath, fileSource, helpers });
+  // 3. AI summary
+  const summary = await summarizeFlow({ relativePath, fileSource });
 
   const flowName = flowNameFromPath(relativePath);
   const orgName = orgNameFromSlug(orgSlug);
@@ -440,7 +291,6 @@ async function generateFlowDoc({
     filePath: relativePath,
     summary,
     steps,
-    helpers,
   };
 }
 
@@ -466,7 +316,7 @@ async function mapWithConcurrency(items, limit, mapper) {
 
 // POST /api/flow-doc/generate
 router.post('/generate', async (req, res) => {
-  const { flowUrl, includeHelpers } = req.body;
+  const { flowUrl } = req.body;
 
   if (!flowUrl || typeof flowUrl !== 'string') {
     return res.status(400).json({ error: 'flowUrl is required.' });
@@ -495,10 +345,10 @@ router.post('/generate', async (req, res) => {
 
   const authHeader = { Authorization: `Bearer ${qawBearerToken}` };
 
-  // 2. Resolve git context (branch/commit + file tree)
-  let branchId, commitHash, filesData;
+  // 2. Resolve git context (branch/commit)
+  let branchId, commitHash;
   try {
-    ({ branchId, commitHash, filesData } = await fetchGitContext({
+    ({ branchId, commitHash } = await fetchGitContext({
       trpcBase,
       authHeader,
       environmentId,
@@ -513,7 +363,6 @@ router.post('/generate', async (req, res) => {
 
   // 3. Generate the doc
   try {
-    const knownPaths = collectKnownPaths(filesData);
     const doc = await generateFlowDoc({
       trpcBase,
       authHeader,
@@ -521,8 +370,6 @@ router.post('/generate', async (req, res) => {
       commitHash,
       relativePath,
       orgSlug,
-      knownPaths,
-      includeHelpers: includeHelpers === true,
     });
     return res.json({ success: true, ...doc });
   } catch (err) {
@@ -590,7 +437,7 @@ router.post('/list-flows', async (req, res) => {
 
 // POST /api/flow-doc/generate-bulk
 router.post('/generate-bulk', async (req, res) => {
-  const { environmentUrl, filePaths, includeHelpers } = req.body;
+  const { environmentUrl, filePaths } = req.body;
 
   if (!environmentUrl || typeof environmentUrl !== 'string') {
     return res.status(400).json({ error: 'environmentUrl is required.' });
@@ -648,8 +495,6 @@ router.post('/generate-bulk', async (req, res) => {
     }
   }
 
-  const knownPaths = collectKnownPaths(filesData);
-
   // 4. Generate a doc per flow with bounded concurrency; capture per-flow failures
   const failures = [];
   let authFailed = false;
@@ -663,8 +508,6 @@ router.post('/generate-bulk', async (req, res) => {
         commitHash,
         relativePath,
         orgSlug,
-        knownPaths,
-        includeHelpers: includeHelpers === true,
       });
     } catch (err) {
       if (err instanceof QawAuthError) authFailed = true;

--- a/frontend/src/projects/flow-doc-generator/FlowDocGenerator.css
+++ b/frontend/src/projects/flow-doc-generator/FlowDocGenerator.css
@@ -257,31 +257,6 @@
   color: rgba(255, 255, 255, 0.5);
 }
 
-.fdg-helpers-toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.85rem;
-  font-size: 0.8125rem;
-  color: rgba(255, 255, 255, 0.8);
-  cursor: pointer;
-  user-select: none;
-  flex-wrap: wrap;
-}
-
-.fdg-helpers-toggle input[type='checkbox'] {
-  width: 1rem;
-  height: 1rem;
-  accent-color: var(--coral);
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-.fdg-helpers-hint {
-  color: rgba(255, 255, 255, 0.45);
-  font-size: 0.75rem;
-}
-
 /* =========================
  * Loading + error states
  * ========================= */
@@ -647,29 +622,6 @@
   background: #ecfdf5;
   color: #065f46;
   border-color: #6ee7b7;
-}
-
-/* =========================
- * Helper files section — lives inside the paper preview, mirrors the
- * steps section but labels each block with its repo path instead of a
- * numbered step pill.
- * ========================= */
-
-.fdg-helpers-section {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  margin-top: 2rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid #e5e7eb;
-}
-
-.fdg-helper-path {
-  font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', Menlo, monospace;
-  font-size: 0.8125rem;
-  font-weight: 700;
-  color: #3d3df5;
-  word-break: break-all;
 }
 
 /* =========================

--- a/frontend/src/projects/flow-doc-generator/index.jsx
+++ b/frontend/src/projects/flow-doc-generator/index.jsx
@@ -68,8 +68,6 @@ function DocOutput({ doc }) {
   const [summary, setSummary] = useState(doc.summary);
   const [steps, setSteps] = useState(doc.steps);
   const [showPrintTip, setShowPrintTip] = useState(false);
-  const helpers = doc.helpers || [];
-
 
   const handleStepNameChange = useCallback((index, newName) => {
     setSteps((prev) => prev.map((s, i) => (i === index ? { ...s, name: newName } : s)));
@@ -117,23 +115,6 @@ function DocOutput({ doc }) {
   </div>`,
     )
     .join('')}
-  ${
-    helpers.length > 0
-      ? `
-  <div class="fdg-summary-block">
-    <h2 class="fdg-section-heading">Helper Files</h2>
-  </div>
-  ${helpers
-    .map(
-      (helper) => `
-  <div class="fdg-step">
-    <h3 class="fdg-step-name-heading">${helper.path}</h3>
-    <pre>${helper.code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>
-  </div>`,
-    )
-    .join('')}`
-      : ''
-  }
 </body>
 </html>`;
 
@@ -219,24 +200,6 @@ function DocOutput({ doc }) {
             <TestStep key={`step-${i}`} step={step} index={i} onNameChange={handleStepNameChange} />
           ))}
         </section>
-
-        {helpers.length > 0 && (
-          <section className="fdg-helpers-section">
-            <h3 className="fdg-section-heading">Helper Files</h3>
-            {helpers.map((helper, i) => (
-              <div className="fdg-step" key={`helper-${i}`}>
-                <h4 className="fdg-step-name-heading">
-                  <span className="fdg-helper-path">{helper.path}</span>
-                </h4>
-                <div className="fdg-code-wrapper">
-                  <pre className="fdg-code-block">
-                    <code>{helper.code}</code>
-                  </pre>
-                </div>
-              </div>
-            ))}
-          </section>
-        )}
       </div>
     </div>
   );
@@ -262,7 +225,6 @@ function authHeaders() {
 function FlowDocGenerator() {
   const toast = useToast();
   const [flowUrl, setFlowUrl] = useState('');
-  const [includeHelpers, setIncludeHelpers] = useState(false);
   const [loading, setLoading] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState(null);
@@ -304,7 +266,7 @@ function FlowDocGenerator() {
       // Environment URL: fetch the flow list first so the user can choose
       // which flows to generate (instead of generating all of them).
       const endpoint = bulk ? '/flow-doc/list-flows' : '/flow-doc/generate';
-      const body = bulk ? { environmentUrl: trimmed } : { flowUrl: trimmed, includeHelpers };
+      const body = bulk ? { environmentUrl: trimmed } : { flowUrl: trimmed };
 
       const res = await fetch(`${API_BASE_URL}${endpoint}`, {
         method: 'POST',
@@ -328,7 +290,7 @@ function FlowDocGenerator() {
     } finally {
       setLoading(false);
     }
-  }, [flowUrl, includeHelpers]);
+  }, [flowUrl]);
 
   const togglePath = useCallback((filePath) => {
     setSelectedPaths((prev) => {
@@ -370,7 +332,6 @@ function FlowDocGenerator() {
         body: JSON.stringify({
           environmentUrl: flowUrl.trim(),
           filePaths: [...selectedPaths],
-          includeHelpers,
         }),
       });
 
@@ -387,7 +348,7 @@ function FlowDocGenerator() {
     } finally {
       setGenerating(false);
     }
-  }, [flowUrl, selectedPaths, includeHelpers]);
+  }, [flowUrl, selectedPaths]);
 
   const openOppModal = useCallback(async () => {
     if (selectedPaths.size === 0) return;
@@ -475,7 +436,7 @@ function FlowDocGenerator() {
               Paste a flow URL (single doc) or an environment URL (one doc per flow) and click{' '}
               <strong>Generate</strong>
             </li>
-            <li>The AI summarizes each flow, extracts its test steps, and pulls in helper files</li>
+            <li>The AI summarizes each flow and extracts its test steps</li>
             <li>
               Click any field — title, summary, or step names — to edit them before downloading
             </li>
@@ -522,19 +483,6 @@ function FlowDocGenerator() {
             {loading ? 'Generating...' : 'Generate'}
           </button>
         </div>
-
-        <label className="fdg-helpers-toggle">
-          <input
-            type="checkbox"
-            checked={includeHelpers}
-            onChange={(e) => setIncludeHelpers(e.target.checked)}
-            disabled={loading}
-          />
-          <span>Include helper files</span>
-          <span className="fdg-helpers-hint">
-            Pulls in utility/helper files imported by the flow. Leave off for a cleaner doc.
-          </span>
-        </label>
       </div>
 
       {loading && (


### PR DESCRIPTION
## Summary
Removes the opt-in "Include helper files" feature from the Howl Sheet (Flow Doc Generator), end to end. Single-flow and bulk generation are otherwise unchanged.

## Changes
- **Backend** (`backend/src/projects/flow-doc-generator/routes/index.js`): removed import-specifier extraction and helper resolution (`extractImportPaths`, `resolveHelperPaths`, `matchInTree`, `collectKnownPaths`, `stripHelperExt`, the `HELPER_*` constants) and the now-unused `path` import; dropped the `includeHelpers` flag and helper context from `generateFlowDoc` / `summarizeFlow` and both the `/generate` and `/generate-bulk` routes.
- **Frontend** (`frontend/src/projects/flow-doc-generator/index.jsx`): removed the "Include helper files" toggle, the helper rendering in the on-screen preview and the print-to-PDF HTML, and all `includeHelpers` request wiring.
- **CSS**: removed the helper toggle and helper-section styles.

## Notes
- Also picks up the stray Prettier formatting fix in `index.jsx` (double blank line + trailing newline) that was left on `main`, so `format:check` is green.

## Test plan
- [ ] Single flow URL (`?file=...`) still generates one doc
- [ ] Environment URL lists flows; selecting + generating works
- [ ] Generated docs (preview + downloaded PDF) no longer show a Helper Files section
- [ ] CI `lint` / `build` / `test` all green

Made with [Cursor](https://cursor.com)