### PR TITLE
Lead Pack view: per-SE drill-down, CARR, and calendars

### DIFF
--- a/backend/src/projects/salesforce/metricsForYear.js
+++ b/backend/src/projects/salesforce/metricsForYear.js
@@ -1,0 +1,82 @@
+/**
+ * Server-side loader for a year's Salesforce metrics `quarterlyData`,
+ * preferring a saved snapshot (no SF round-trip) and falling back to a
+ * live report fetch. Returns the same per-quarter shape the HTTP routes
+ * emit — each quarter carries an `opportunities` array whose entries
+ * include `opportunityId`, `carrAmount`, and `accountScore`.
+ *
+ * Extracted so non-HTTP consumers (e.g. the pack CARR roll-up) can reuse
+ * the metrics without going back through the REST layer.
+ */
+import { readFileSync } from 'fs';
+import {
+  getSalesforceConnection,
+  getQuarterName,
+  readSnapshotRegistry,
+  SNAPSHOTS_DIR,
+} from './functions.js';
+import { detectHasAccountScore, getMetricsColumnIndices } from './reportShape.js';
+import { getSalesforceConfig } from '../../config/salesforce.js';
+
+// Parse a raw jsforce metrics report result into the lightweight
+// per-quarter shape we need for CARR attribution. Mirrors the column
+// handling in snapshotService / the /report route, but only keeps the
+// fields the roll-up actually uses.
+function buildQuarterlyData(metricsResult) {
+  const hasAccountScore = detectHasAccountScore(metricsResult.factMap);
+  const cols = getMetricsColumnIndices(hasAccountScore);
+  const quarterlyData = {};
+
+  for (const quarterKey of Object.keys(metricsResult.factMap || {})) {
+    const quarterData = metricsResult.factMap[quarterKey];
+    const quarterName = getQuarterName(quarterKey, metricsResult.groupingsDown);
+    if (quarterName === 'Total') continue;
+
+    const opportunities = [];
+    if (Array.isArray(quarterData?.rows)) {
+      for (const row of quarterData.rows) {
+        const dataCells = row.dataCells;
+        opportunities.push({
+          opportunityId: dataCells[cols.opportunityName]?.value || '',
+          opportunityName: dataCells[cols.opportunityName]?.label || '',
+          aeName: dataCells[cols.aeName]?.label || '',
+          aeId: dataCells[cols.aeName]?.value || '',
+          accountScore: cols.accountScore >= 0 ? dataCells[cols.accountScore]?.label || '' : '',
+          carrAmount: dataCells[cols.carr]?.value?.amount || 0,
+          quarter: quarterName,
+        });
+      }
+    }
+    quarterlyData[quarterName] = { quarter: quarterName, opportunities };
+  }
+  return quarterlyData;
+}
+
+/**
+ * Resolve a year's metrics `quarterlyData`. Snapshot first, then live.
+ * Returns null when the year is neither snapshotted nor configured with a
+ * live report id (the caller treats that as "CARR unavailable").
+ *
+ * @param {number} year
+ * @returns {Promise<Record<string, { quarter: string, opportunities: object[] }> | null>}
+ */
+export async function getMetricsQuarterlyDataForYear(year) {
+  const registry = readSnapshotRegistry();
+  if (registry.years.includes(year)) {
+    try {
+      const raw = readFileSync(`${SNAPSHOTS_DIR}/${year}-metrics.json`, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (parsed?.quarterlyData) return parsed.quarterlyData;
+    } catch {
+      // Fall through to a live fetch if the snapshot file is missing/corrupt.
+    }
+  }
+
+  const config = getSalesforceConfig();
+  const reportId = config.reportIdsByYear?.[year]?.metrics;
+  if (!reportId) return null;
+
+  const conn = await getSalesforceConnection();
+  const metricsResult = await conn.analytics.report(reportId).execute({ details: true });
+  return buildQuarterlyData(metricsResult);
+}

--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -2,10 +2,16 @@ import express from 'express';
 import { authenticateToken } from '../middleware/auth.js';
 import {
   getClosedLinearTicketsForUser,
+  getClosedTicketsForAllSEs,
   getLinearBoardForDashboardForUser,
   getTicketsCreatedByAEForTeam,
+  getTicketsForSE,
 } from '../services/linearDashboardService.js';
-import { getTodayCalendarForDashboard } from '../services/googleCalendarDashboardService.js';
+import {
+  getCalendarForSE,
+  getTodayCalendarForDashboard,
+} from '../services/googleCalendarDashboardService.js';
+import { getPackCarr } from '../services/packCarrService.js';
 
 const router = express.Router();
 
@@ -56,6 +62,101 @@ router.get('/linear/tickets-by-ae', authenticateToken, async (req, res) => {
   } catch (err) {
     console.error('GET /api/dashboard/linear/tickets-by-ae:', err);
     res.status(500).json({ error: err.message || 'Failed to load tickets by AE' });
+  }
+});
+
+// Lead Pack overview: per-SE closed-ticket roll-up for every active Sales
+// Engineer, plus each SE's assigned AE roster. Powers the team page's
+// lead-only "Pack" view. Gated to admins / SE leads (same rule as
+// /opps/sales-engineers) since regular SEs shouldn't see the whole pack's
+// numbers. Year defaults to the current calendar year with the same bounds
+// as /linear/closed so a malformed query can't widen the GraphQL window.
+router.get('/pack-overview', authenticateToken, async (req, res) => {
+  const roles = req.user?.roles || [];
+  if (!roles.includes('admin') && !roles.includes('sales_engineer_lead')) {
+    return res.status(403).json({ error: 'Insufficient permissions' });
+  }
+  const now = new Date();
+  const requestedYear = Number.parseInt(req.query.year, 10);
+  const year =
+    Number.isInteger(requestedYear) && requestedYear >= 2020 && requestedYear <= 2035
+      ? requestedYear
+      : now.getUTCFullYear();
+  try {
+    const payload = await getClosedTicketsForAllSEs(year);
+    res.json(payload);
+  } catch (err) {
+    console.error('GET /api/dashboard/pack-overview:', err);
+    res.status(500).json({ error: err.message || 'Failed to load pack overview' });
+  }
+});
+
+// Lead Pack CARR: per-SE Closed CARR roll-up, attributed via handoff pages
+// (SF opportunityId -> Opp -> SE). Same lead/admin gate as /pack-overview.
+// Year defaults to the current calendar year with the same bounds.
+router.get('/pack-carr', authenticateToken, async (req, res) => {
+  const roles = req.user?.roles || [];
+  if (!roles.includes('admin') && !roles.includes('sales_engineer_lead')) {
+    return res.status(403).json({ error: 'Insufficient permissions' });
+  }
+  const now = new Date();
+  const requestedYear = Number.parseInt(req.query.year, 10);
+  const year =
+    Number.isInteger(requestedYear) && requestedYear >= 2020 && requestedYear <= 2035
+      ? requestedYear
+      : now.getUTCFullYear();
+  try {
+    const payload = await getPackCarr(year);
+    res.json(payload);
+  } catch (err) {
+    console.error('GET /api/dashboard/pack-carr:', err);
+    res.status(500).json({ error: err.message || 'Failed to load pack CARR' });
+  }
+});
+
+// Pack drill-down: actual Linear tickets (open workload + closed-this-year)
+// for a single Sales Engineer. Powers the team page's per-SE detail view.
+// Same lead/admin gate as /pack-overview since it exposes another SE's work.
+router.get('/pack-overview/:seId/tickets', authenticateToken, async (req, res) => {
+  const roles = req.user?.roles || [];
+  if (!roles.includes('admin') && !roles.includes('sales_engineer_lead')) {
+    return res.status(403).json({ error: 'Insufficient permissions' });
+  }
+  const now = new Date();
+  const requestedYear = Number.parseInt(req.query.year, 10);
+  const year =
+    Number.isInteger(requestedYear) && requestedYear >= 2020 && requestedYear <= 2035
+      ? requestedYear
+      : now.getUTCFullYear();
+  try {
+    const payload = await getTicketsForSE(req.params.seId, year);
+    res.json(payload);
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return res.status(404).json({ error: 'Sales Engineer not found' });
+    }
+    console.error('GET /api/dashboard/pack-overview/:seId/tickets:', err);
+    res.status(500).json({ error: err.message || 'Failed to load SE tickets' });
+  }
+});
+
+// Pack drill-down: today's calendar for a single Sales Engineer. Same
+// lead/admin gate as the other pack-overview routes since it exposes another
+// SE's schedule. Only reads the SE's own connected Google calendar.
+router.get('/pack-overview/:seId/calendar', authenticateToken, async (req, res) => {
+  const roles = req.user?.roles || [];
+  if (!roles.includes('admin') && !roles.includes('sales_engineer_lead')) {
+    return res.status(403).json({ error: 'Insufficient permissions' });
+  }
+  try {
+    const payload = await getCalendarForSE(req.params.seId);
+    res.json(payload);
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return res.status(404).json({ error: 'Sales Engineer not found' });
+    }
+    console.error('GET /api/dashboard/pack-overview/:seId/calendar:', err);
+    res.status(500).json({ error: err.message || 'Failed to load SE calendar' });
   }
 });
 

--- a/backend/src/services/googleCalendarDashboardService.js
+++ b/backend/src/services/googleCalendarDashboardService.js
@@ -320,3 +320,36 @@ export async function getTodayCalendarForDashboard(userId) {
   }
   return { configured: false, events: [], source: null };
 }
+
+/**
+ * Today's calendar for a single Sales Engineer, for the lead Pack drill-down.
+ * Resolves the SE to their app user, then reads *only* that user's connected
+ * Google calendar — never the shared service-account calendar, which would
+ * show one identical calendar for every SE. `configured: false` means the SE
+ * hasn't linked their Google account yet.
+ *
+ * @returns {Promise<{ seId: string, name: string, configured: boolean, source: 'oauth' | null, events: Array }>}
+ */
+export async function getCalendarForSE(seId) {
+  const prisma = await getPrisma();
+  const se = await prisma.salesEngineer.findUnique({
+    where: { id: seId },
+    include: { user: true },
+  });
+  if (!se) {
+    const err = new Error('Sales Engineer not found');
+    err.statusCode = 404;
+    throw err;
+  }
+
+  const fullName = `${se.user?.firstName || ''} ${se.user?.lastName || ''}`.trim();
+  const base = { seId: se.id, name: fullName || se.user?.email || 'Unknown SE' };
+
+  const result = await getTodayCalendarEventsForUser(se.userId);
+  return {
+    ...base,
+    configured: result.configured,
+    source: result.configured ? 'oauth' : null,
+    events: result.events,
+  };
+}

--- a/backend/src/services/linearDashboardService.js
+++ b/backend/src/services/linearDashboardService.js
@@ -467,6 +467,7 @@ const CLOSED_TICKETS_QUERY = `
         identifier
         title
         url
+        dueDate
         createdAt
         completedAt
         state { name type }
@@ -655,6 +656,127 @@ function emptyQuarterlyBuckets(year) {
  *   error?: 'linear_unavailable',
  * }>}
  */
+// Collapse a flat list of completed Linear issues into the per-quarter +
+// yearly-total roll-up the team page renders. Extracted from
+// `getClosedLinearTicketsForUser` so the pack-overview service can reuse
+// the exact same binning/averaging without duplicating the (subtle)
+// category/month logic. Pure over its inputs — no Prisma, no Linear I/O.
+function aggregateClosedIssues(issues, year) {
+  // First pass: bin the raw issues into per-quarter, per-category
+  // arrays. We hold onto the full issue objects (not just counts)
+  // because the second pass needs createdAt/completedAt to compute
+  // averages — running the maths inline would force two iterations
+  // anyway and would leak avg-tracking state into the loop.
+  const grouped = {};
+  const allByCategory = {
+    estimation: [],
+    creation: [],
+    aiDemo: [],
+    other: [],
+  };
+  for (const issue of issues) {
+    const quarterKey = quarterKeyOfDate(issue.completedAt);
+    if (!quarterKey) continue;
+    if (!grouped[quarterKey]) {
+      grouped[quarterKey] = {
+        estimation: [],
+        creation: [],
+        aiDemo: [],
+        other: [],
+      };
+    }
+    const category = classifyClosedIssue(issue);
+    grouped[quarterKey][category].push(issue);
+    allByCategory[category].push(issue);
+  }
+
+  // Second pass: collapse each bucket into the count + avg shape
+  // the frontend renders. Buckets the SE didn't touch this quarter
+  // keep the empty defaults from `emptyQuarterlyBuckets` (including
+  // the pre-seeded byMonth zero-bars).
+  const byQuarter = emptyQuarterlyBuckets(year);
+  for (const [quarterKey, bucket] of Object.entries(grouped)) {
+    if (!byQuarter[quarterKey]) continue;
+    const all = [...bucket.estimation, ...bucket.creation, ...bucket.aiDemo, ...bucket.other];
+
+    // Build the byMonth array fresh from the empty seed so the
+    // three months stay in chronological order even when the
+    // grouping happened to populate them out of order.
+    const quarter = byQuarter[quarterKey].quarter;
+    const byMonth = monthsOfQuarter(quarter).map(emptyMonthBucket);
+    const monthIndex = new Map(byMonth.map((m) => [m.month, m]));
+    // Walk each issue in this quarter and increment the month
+    // bucket it falls into. We classify per issue instead of
+    // reusing `category` from the outer loop because the month
+    // sub-totals need the same per-issue branching.
+    for (const issue of all) {
+      const completed = issue.completedAt ? new Date(issue.completedAt) : null;
+      if (!completed || Number.isNaN(completed.getTime())) continue;
+      const month = completed.getUTCMonth() + 1;
+      const monthBucket = monthIndex.get(month);
+      if (!monthBucket) continue;
+      const cat = classifyClosedIssue(issue);
+      monthBucket[cat] += 1;
+      monthBucket.total += 1;
+    }
+
+    byQuarter[quarterKey] = {
+      quarter,
+      estimation: bucket.estimation.length,
+      creation: bucket.creation.length,
+      aiDemo: bucket.aiDemo.length,
+      other: bucket.other.length,
+      total: all.length,
+      avgDaysEstimation: averageDaysToClose(bucket.estimation),
+      avgDaysCreation: averageDaysToClose(bucket.creation),
+      avgDaysAiDemo: averageDaysToClose(bucket.aiDemo),
+      avgDaysOther: averageDaysToClose(bucket.other),
+      avgDaysTotal: averageDaysToClose(all),
+      byMonth,
+      // Slim row shape (id/identifier/title/completedAt/url) so the
+      // frontend can render a "Show N 'Other' tickets" disclosure
+      // without us shipping the full Linear issue blob over the
+      // wire. Sorted newest-first so the most recent unmatched
+      // tickets surface at the top of the list.
+      otherTickets: bucket.other
+        .slice()
+        .sort((a, b) => {
+          const ta = a.completedAt ? Date.parse(a.completedAt) : 0;
+          const tb = b.completedAt ? Date.parse(b.completedAt) : 0;
+          return tb - ta;
+        })
+        .map((issue) => ({
+          id: issue.id,
+          identifier: issue.identifier || null,
+          title: issue.title || '(untitled)',
+          completedAt: issue.completedAt || null,
+          url: issue.url || null,
+        })),
+    };
+  }
+
+  const allIssues = [
+    ...allByCategory.estimation,
+    ...allByCategory.creation,
+    ...allByCategory.aiDemo,
+    ...allByCategory.other,
+  ];
+  const total = {
+    estimation: allByCategory.estimation.length,
+    creation: allByCategory.creation.length,
+    aiDemo: allByCategory.aiDemo.length,
+    other: allByCategory.other.length,
+    total: allIssues.length,
+    avgDaysEstimation: averageDaysToClose(allByCategory.estimation),
+    avgDaysCreation: averageDaysToClose(allByCategory.creation),
+    avgDaysAiDemo: averageDaysToClose(allByCategory.aiDemo),
+    avgDaysOther: averageDaysToClose(allByCategory.other),
+    avgDaysTotal: averageDaysToClose(allIssues),
+  };
+
+  return { byQuarter, total };
+}
+
 export async function getClosedLinearTicketsForUser(userId, year) {
   const empty = {
     configured: false,
@@ -684,124 +806,225 @@ export async function getClosedLinearTicketsForUser(userId, year) {
 
   try {
     const issues = await fetchMyClosedTickets(resolved.linearUserId, year);
-
-    // First pass: bin the raw issues into per-quarter, per-category
-    // arrays. We hold onto the full issue objects (not just counts)
-    // because the second pass needs createdAt/completedAt to compute
-    // averages — running the maths inline would force two iterations
-    // anyway and would leak avg-tracking state into the loop.
-    const grouped = {};
-    const allByCategory = {
-      estimation: [],
-      creation: [],
-      aiDemo: [],
-      other: [],
-    };
-    for (const issue of issues) {
-      const quarterKey = quarterKeyOfDate(issue.completedAt);
-      if (!quarterKey) continue;
-      if (!grouped[quarterKey]) {
-        grouped[quarterKey] = {
-          estimation: [],
-          creation: [],
-          aiDemo: [],
-          other: [],
-        };
-      }
-      const category = classifyClosedIssue(issue);
-      grouped[quarterKey][category].push(issue);
-      allByCategory[category].push(issue);
-    }
-
-    // Second pass: collapse each bucket into the count + avg shape
-    // the frontend renders. Buckets the SE didn't touch this quarter
-    // keep the empty defaults from `emptyQuarterlyBuckets` (including
-    // the pre-seeded byMonth zero-bars).
-    const byQuarter = emptyQuarterlyBuckets(year);
-    for (const [quarterKey, bucket] of Object.entries(grouped)) {
-      if (!byQuarter[quarterKey]) continue;
-      const all = [...bucket.estimation, ...bucket.creation, ...bucket.aiDemo, ...bucket.other];
-
-      // Build the byMonth array fresh from the empty seed so the
-      // three months stay in chronological order even when the
-      // grouping happened to populate them out of order.
-      const quarter = byQuarter[quarterKey].quarter;
-      const byMonth = monthsOfQuarter(quarter).map(emptyMonthBucket);
-      const monthIndex = new Map(byMonth.map((m) => [m.month, m]));
-      // Walk each issue in this quarter and increment the month
-      // bucket it falls into. We classify per issue instead of
-      // reusing `category` from the outer loop because the month
-      // sub-totals need the same per-issue branching.
-      for (const issue of all) {
-        const completed = issue.completedAt ? new Date(issue.completedAt) : null;
-        if (!completed || Number.isNaN(completed.getTime())) continue;
-        const month = completed.getUTCMonth() + 1;
-        const monthBucket = monthIndex.get(month);
-        if (!monthBucket) continue;
-        const cat = classifyClosedIssue(issue);
-        monthBucket[cat] += 1;
-        monthBucket.total += 1;
-      }
-
-      byQuarter[quarterKey] = {
-        quarter,
-        estimation: bucket.estimation.length,
-        creation: bucket.creation.length,
-        aiDemo: bucket.aiDemo.length,
-        other: bucket.other.length,
-        total: all.length,
-        avgDaysEstimation: averageDaysToClose(bucket.estimation),
-        avgDaysCreation: averageDaysToClose(bucket.creation),
-        avgDaysAiDemo: averageDaysToClose(bucket.aiDemo),
-        avgDaysOther: averageDaysToClose(bucket.other),
-        avgDaysTotal: averageDaysToClose(all),
-        byMonth,
-        // Slim row shape (id/identifier/title/completedAt/url) so the
-        // frontend can render a "Show N 'Other' tickets" disclosure
-        // without us shipping the full Linear issue blob over the
-        // wire. Sorted newest-first so the most recent unmatched
-        // tickets surface at the top of the list.
-        otherTickets: bucket.other
-          .slice()
-          .sort((a, b) => {
-            const ta = a.completedAt ? Date.parse(a.completedAt) : 0;
-            const tb = b.completedAt ? Date.parse(b.completedAt) : 0;
-            return tb - ta;
-          })
-          .map((issue) => ({
-            id: issue.id,
-            identifier: issue.identifier || null,
-            title: issue.title || '(untitled)',
-            completedAt: issue.completedAt || null,
-            url: issue.url || null,
-          })),
-      };
-    }
-
-    const allIssues = [
-      ...allByCategory.estimation,
-      ...allByCategory.creation,
-      ...allByCategory.aiDemo,
-      ...allByCategory.other,
-    ];
-    const total = {
-      estimation: allByCategory.estimation.length,
-      creation: allByCategory.creation.length,
-      aiDemo: allByCategory.aiDemo.length,
-      other: allByCategory.other.length,
-      total: allIssues.length,
-      avgDaysEstimation: averageDaysToClose(allByCategory.estimation),
-      avgDaysCreation: averageDaysToClose(allByCategory.creation),
-      avgDaysAiDemo: averageDaysToClose(allByCategory.aiDemo),
-      avgDaysOther: averageDaysToClose(allByCategory.other),
-      avgDaysTotal: averageDaysToClose(allIssues),
-    };
-
+    const { byQuarter, total } = aggregateClosedIssues(issues, year);
     return { configured: true, year, byQuarter, total };
   } catch (err) {
     console.error('Linear: closed-ticket fetch failed for user', userId, '-', err.message);
     return { ...empty, error: 'linear_unavailable' };
   }
+}
+
+// ---- Pack-wide closed-ticket roll-up (lead "Pack" view) ------------------
+//
+// Lead-facing variant of `getClosedLinearTicketsForUser`: instead of a
+// single SE, walk EVERY active Sales Engineer and return each one's closed
+// roll-up (Creation / Scoping / completed counts). Linear-only — the team
+// page surfaces these directly without any Salesforce/AE attribution.
+
+// Run `mapper` over `items` with at most `size` promises in flight at once.
+// Each SE is its own paginated Linear query, so unbounded Promise.all would
+// fire N concurrent multi-page fetches; chunking keeps the Linear API
+// (and our worker) from getting hammered when the pack grows.
+async function mapWithConcurrency(items, size, mapper) {
+  const results = [];
+  for (let i = 0; i < items.length; i += size) {
+    const chunk = items.slice(i, i + size);
+    const settled = await Promise.all(chunk.map(mapper));
+    results.push(...settled);
+  }
+  return results;
+}
+
+// Zeroed closed roll-up for SEs we couldn't fetch Linear data for (no
+// resolvable Linear profile, or a per-SE fetch error). Mirrors the shape
+// of `aggregateClosedIssues` so the frontend can read every row the same
+// way regardless of whether Linear resolved.
+function emptyClosedRollup(year) {
+  return {
+    byQuarter: emptyQuarterlyBuckets(year),
+    total: {
+      estimation: 0,
+      creation: 0,
+      aiDemo: 0,
+      other: 0,
+      total: 0,
+      avgDaysEstimation: null,
+      avgDaysCreation: null,
+      avgDaysAiDemo: null,
+      avgDaysOther: null,
+      avgDaysTotal: null,
+    },
+  };
+}
+
+/**
+ * Per-SE closed-ticket roll-up for the lead Pack view.
+ *
+ * Loads every active Sales Engineer, resolves each SE's Linear user id,
+ * fetches their completed tickets for the year (aggregated with the same
+ * logic the personal team-page roll-up uses) AND their currently-open
+ * in-flight tickets (the `open` count = live workload, independent of the
+ * year/quarter scope). SEs whose Linear profile can't be resolved (or
+ * whose fetch fails) still appear with zeroed counts so the lead always
+ * sees the full pack.
+ *
+ * @param {number} year
+ * @returns {Promise<{
+ *   configured: boolean,
+ *   year: number,
+ *   sets: Array<{
+ *     seId: string,
+ *     userId: string,
+ *     name: string,
+ *     email: string | null,
+ *     open: number,
+ *     closed: { byQuarter: Record<string, object>, total: object },
+ *   }>,
+ * }>}
+ */
+export async function getClosedTicketsForAllSEs(year) {
+  const teamId = process.env.LINEAR_TEAM_ID?.trim();
+  const apiKey = process.env.LINEAR_API_KEY?.trim();
+  const configured = Boolean(teamId && apiKey);
+
+  const prisma = await getPrisma();
+  const ses = await prisma.salesEngineer.findMany({
+    where: { isActive: true },
+    include: { user: true },
+    orderBy: { id: 'asc' },
+  });
+
+  const sets = await mapWithConcurrency(ses, 4, async (se) => {
+    const fullName = `${se.user?.firstName || ''} ${se.user?.lastName || ''}`.trim();
+    const base = {
+      seId: se.id,
+      userId: se.userId,
+      name: fullName || se.user?.email || 'Unknown SE',
+      email: se.user?.email || null,
+    };
+
+    if (!configured) {
+      return { ...base, open: 0, closed: emptyClosedRollup(year) };
+    }
+
+    try {
+      const resolved = await loadOrResolveLinearUserId(se.userId);
+      if (resolved.status !== 'ok') {
+        return { ...base, open: 0, closed: emptyClosedRollup(year) };
+      }
+      // Pull closed (year) and open (live) tickets in parallel. Open
+      // tickets are the SE's "current workload" — what's assigned and
+      // still in flight right now, so it ignores the year/quarter scope.
+      const [closedIssues, openIssues] = await Promise.all([
+        fetchMyClosedTickets(resolved.linearUserId, year),
+        fetchMyTeamIssues(resolved.linearUserId),
+      ]);
+      const { byQuarter, total } = aggregateClosedIssues(closedIssues, year);
+      // Exclude internal/tooling projects so the count matches the
+      // "Active Hunts" definition the dashboard uses.
+      const open = openIssues.filter((i) => !isExcludedProjectName(i.project?.name)).length;
+      return { ...base, open, closed: { byQuarter, total } };
+    } catch (err) {
+      console.error('Linear: pack ticket fetch failed for SE', se.id, '-', err.message);
+      return { ...base, open: 0, closed: emptyClosedRollup(year) };
+    }
+  });
+
+  // Stable alphabetical order so the lead's table doesn't reshuffle on
+  // every fetch (the frontend re-sorts by whichever column anyway).
+  sets.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+
+  return { configured, year, sets };
+}
+
+// Lightweight ticket shape for the pack drill-down list. We hand-roll
+// this instead of reusing `mapIssue` because that helper drops the
+// `url` (and we want a deep-link) and is geared at the open-issues
+// widget specifically. `category` reuses the same classifier the
+// roll-up counts with so the list and the headline tiles always agree.
+function mapTicketForList(issue) {
+  // Prefer Linear's native due date; fall back to the "Due Date" field
+  // SE ticket templates stash in the description (only present for the
+  // open-issues query, which fetches `description`). Closed tickets fall
+  // through to the native field or null.
+  const dueDate = issue.dueDate || extractDescriptionField(issue.description, 'Due Date') || null;
+  return {
+    id: issue.identifier || issue.id,
+    title: issue.title || 'Untitled ticket',
+    url: issue.url || null,
+    project: issue.project?.name || null,
+    status: issue.state?.name || null,
+    dueDate,
+    category: classifyClosedIssue(issue),
+    completedAt: issue.completedAt || null,
+    createdAt: issue.createdAt || null,
+  };
+}
+
+/**
+ * Actual Linear tickets for a single Sales Engineer, for the pack
+ * drill-down. Returns the SE's live open workload plus every ticket they
+ * completed in `year`, each as a linkable row. Lead-only data — the route
+ * that calls this is gated to admins / SE leads.
+ *
+ * @param {string} seId  SalesEngineer.id
+ * @param {number} year  calendar year for the closed-ticket window
+ * @returns {Promise<{
+ *   configured: boolean,
+ *   seId: string,
+ *   name: string,
+ *   year: number,
+ *   open: object[],
+ *   closed: object[],
+ * }>}
+ */
+export async function getTicketsForSE(seId, year) {
+  const prisma = await getPrisma();
+  const se = await prisma.salesEngineer.findUnique({
+    where: { id: seId },
+    include: { user: true },
+  });
+  if (!se) {
+    const err = new Error('Sales Engineer not found');
+    err.statusCode = 404;
+    throw err;
+  }
+
+  const fullName = `${se.user?.firstName || ''} ${se.user?.lastName || ''}`.trim();
+  const base = {
+    seId: se.id,
+    name: fullName || se.user?.email || 'Unknown SE',
+    year,
+  };
+
+  const teamId = process.env.LINEAR_TEAM_ID?.trim();
+  const apiKey = process.env.LINEAR_API_KEY?.trim();
+  if (!teamId || !apiKey) {
+    return { ...base, configured: false, open: [], closed: [] };
+  }
+
+  const resolved = await loadOrResolveLinearUserId(se.userId);
+  if (resolved.status !== 'ok') {
+    return { ...base, configured: true, open: [], closed: [] };
+  }
+
+  const [openRaw, closedRaw] = await Promise.all([
+    fetchMyTeamIssues(resolved.linearUserId),
+    fetchMyClosedTickets(resolved.linearUserId, year),
+  ]);
+
+  // Open workload mirrors the "Active Hunts" definition: drop internal /
+  // tooling projects so the list matches the count on the chart.
+  const open = openRaw.filter((i) => !isExcludedProjectName(i.project?.name)).map(mapTicketForList);
+
+  // Most-recently-closed first so the list reads top-down chronologically.
+  const closed = closedRaw.map(mapTicketForList).sort((a, b) => {
+    const ta = a.completedAt ? Date.parse(a.completedAt) : 0;
+    const tb = b.completedAt ? Date.parse(b.completedAt) : 0;
+    return tb - ta;
+  });
+
+  return { ...base, configured: true, open, closed };
 }
 
 // ---- Tickets created BY AE (team page roll-up) ---------------------------

--- a/backend/src/services/packCarrService.js
+++ b/backend/src/services/packCarrService.js
@@ -1,0 +1,94 @@
+/**
+ * Per-SE Closed CARR roll-up for the lead's "Pack" view.
+ *
+ * Salesforce has no SE field on an opportunity, so we attribute a deal's
+ * CARR through its Account Executive: each opportunity carries an AE
+ * (Salesforce id + name), every AccountExecutive belongs to a Team, and
+ * each Team has exactly one Sales Engineer. So `opp.AE -> AE.team -> SE`.
+ * We match the AE by Salesforce id first (exact) and fall back to a
+ * normalized name match (covers AEs seeded without a real SF id). We pull
+ * the year's metrics (snapshot or live), drop C-accounts to match the
+ * dashboard's headline CARR, and sum each deal onto the owning SE.
+ */
+import { getPrisma } from '../lib/prisma.js';
+import { getMetricsQuarterlyDataForYear } from '../projects/salesforce/metricsForYear.js';
+
+function normalizeName(name) {
+  return typeof name === 'string' ? name.trim().toLowerCase() : '';
+}
+
+/**
+ * @param {number} year calendar year for the CARR window
+ * @returns {Promise<{
+ *   configured: boolean,
+ *   year: number,
+ *   sets: Array<{ seId, userId, name, byQuarter: Record<string, number>, total: number }>,
+ * }>}
+ */
+export async function getPackCarr(year) {
+  const prisma = await getPrisma();
+  const ses = await prisma.salesEngineer.findMany({
+    where: { isActive: true },
+    include: { user: true },
+    orderBy: { id: 'asc' },
+  });
+
+  // Seed a record per SE, plus a teamId -> seId lookup (one SE per team).
+  const bySe = new Map();
+  const teamToSe = new Map();
+  for (const se of ses) {
+    const fullName = `${se.user?.firstName || ''} ${se.user?.lastName || ''}`.trim();
+    bySe.set(se.id, {
+      seId: se.id,
+      userId: se.userId,
+      name: fullName || se.user?.email || 'Unknown SE',
+      byQuarter: {},
+      total: 0,
+    });
+    if (se.teamId) teamToSe.set(se.teamId, se.id);
+  }
+
+  // Resolve each AE to the SE of their team. Include inactive AEs so
+  // historical deals still attribute. Index by both Salesforce id and
+  // normalized name for matching against the report.
+  const aes = await prisma.accountExecutive.findMany({
+    select: { name: true, salesforceId: true, teamId: true },
+  });
+  const aeSfIdToSe = new Map();
+  const aeNameToSe = new Map();
+  for (const ae of aes) {
+    const seId = teamToSe.get(ae.teamId);
+    if (!seId) continue;
+    if (ae.salesforceId) aeSfIdToSe.set(ae.salesforceId, seId);
+    if (ae.name) aeNameToSe.set(normalizeName(ae.name), seId);
+  }
+
+  let quarterly = null;
+  try {
+    quarterly = await getMetricsQuarterlyDataForYear(year);
+  } catch (err) {
+    console.error('pack-carr: metrics load failed -', err.message);
+  }
+
+  if (!quarterly) {
+    return { configured: false, year, sets: Array.from(bySe.values()) };
+  }
+
+  for (const [quarterName, q] of Object.entries(quarterly)) {
+    if (quarterName === 'Total') continue;
+    for (const opp of q.opportunities || []) {
+      // Exclude C-accounts so this matches the dashboard's headline CARR.
+      if (opp.accountScore === 'C') continue;
+      // AE Salesforce id first (exact), then fall back to AE name.
+      const seId =
+        (opp.aeId && aeSfIdToSe.get(opp.aeId)) || aeNameToSe.get(normalizeName(opp.aeName));
+      if (!seId) continue;
+      const rec = bySe.get(seId);
+      const amount = opp.carrAmount || 0;
+      rec.byQuarter[quarterName] = (rec.byQuarter[quarterName] || 0) + amount;
+      rec.total += amount;
+    }
+  }
+
+  return { configured: true, year, sets: Array.from(bySe.values()) };
+}

--- a/frontend/src/projects/team/index.jsx
+++ b/frontend/src/projects/team/index.jsx
@@ -1,21 +1,22 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import {
-  LuChartBar,
-  LuClipboardCheck,
-  LuFilePen,
-  LuHammer,
+  LuArrowLeft,
+  LuCalendar,
+  LuChevronDown,
+  LuCircleCheck,
+  LuExternalLink,
+  LuFilePlus,
+  LuInbox,
+  LuRuler,
   LuSparkles,
-  LuTrendingUp,
-  LuTrophy,
 } from 'react-icons/lu';
 import { useAuth } from '../../contexts/AuthContext';
 import {
-  fetchDashboardLinearClosed,
-  fetchDashboardLinearTicketsByAE,
-  fetchSalesforceReport,
-  fetchSalesforceSnapshotMetrics,
-  getSalesforceConfig,
+  fetchPackCarr,
+  fetchPackOverview,
+  fetchPackSeCalendar,
+  fetchPackSeTickets,
 } from '../../services/api';
 import { toTeamSlug } from './slug';
 import './team.less';
@@ -47,280 +48,127 @@ const TEAM_MASCOTS = {
   },
 };
 
-// We share localStorage keys with `<CurrentQuarterMetrics />` on purpose —
-// when the SE has already loaded The Den, the team page hydrates from
-// the warm cache instead of waiting on a fresh Salesforce round-trip,
-// and vice versa.
-const CONFIG_CACHE_KEY = 'currentQuarterMetrics.config';
-const DATA_CACHE_KEY = 'currentQuarterMetrics.dataByYear';
-
-// Resolve the year whose metrics report we should pull. Mirrors the same
-// logic CurrentQuarterMetrics uses: prefer the current calendar year if
-// it has data, otherwise fall back to the most recent configured year
-// that has either a snapshot or a live report ID.
-function resolveDataYear(config) {
-  const calendarYear = new Date().getFullYear();
-  if (!config) return calendarYear;
-  const hasData = (yr) =>
-    (config.snapshotYears || []).includes(yr) || !!config.reportIdsByYear?.[yr]?.metrics;
-  if (hasData(calendarYear)) return calendarYear;
-  const allYears = [
-    ...new Set([
-      ...Object.keys(config.reportIdsByYear || {}).map(Number),
-      ...(config.snapshotYears || []),
-    ]),
-  ].sort((a, b) => b - a);
-  return allYears.find(hasData) ?? calendarYear;
+// Calendar helpers for the year/quarter scope controls.
+function getCurrentYear() {
+  return new Date().getFullYear();
 }
 
-function readCachedConfig() {
-  try {
-    const raw = localStorage.getItem(CONFIG_CACHE_KEY);
-    return raw ? JSON.parse(raw) : null;
-  } catch {
-    return null;
-  }
+// Years offered in the scope dropdown: current year and the two prior.
+const AVAILABLE_YEARS = [getCurrentYear(), getCurrentYear() - 1, getCurrentYear() - 2];
+
+// `quarter` of 0 means "full year"; 1-4 selects a specific quarter. The
+// report's roll-ups are keyed like "Q2 CY2026", so build that on demand.
+function buildQuarterKey(year, quarter) {
+  return quarter ? `Q${quarter} CY${year}` : null;
 }
 
-function readCachedData(year) {
-  try {
-    const raw = localStorage.getItem(DATA_CACHE_KEY);
-    if (!raw) return null;
-    const byYear = JSON.parse(raw);
-    return byYear?.[year] ?? null;
-  } catch {
-    return null;
-  }
+// Human label for the active scope — "Q2 2026" or just "2026".
+function buildPeriodLabel(year, quarter) {
+  return quarter ? `Q${quarter} ${year}` : `${year}`;
 }
 
-function writeCachedData(year, payload) {
-  try {
-    const raw = localStorage.getItem(DATA_CACHE_KEY);
-    const byYear = raw ? JSON.parse(raw) : {};
-    byYear[year] = payload;
-    localStorage.setItem(DATA_CACHE_KEY, JSON.stringify(byYear));
-  } catch {
-    // ignore quota / serialization issues — cache is best-effort
-  }
+// Compact USD for the CARR breakdown: $1.2M / $540K / $0. Keeps the bars
+// readable without long, comma-heavy numbers.
+function formatCompactUSD(amount) {
+  const n = Number(amount) || 0;
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+  if (n >= 1_000) return `$${Math.round(n / 1_000)}K`;
+  return `$${Math.round(n)}`;
 }
 
-function normalizeName(name) {
-  return typeof name === 'string' ? name.trim().toLowerCase() : '';
-}
+// Grouped bar chart geometry. The viewBox is fixed in user-space units
+// and CSS scales the SVG to fill its container, so tweaks here reflow
+// automatically without touching the JSX.
+const CHART = { w: 760, h: 340, padTop: 16, padRight: 12, padBottom: 56, padLeft: 40 };
 
-// Find the bucket for an AE in the backend's `byAE` map. We do an
-// exact normalized-name match first, then fall back to a fuzzy match
-// (same last name + first-name prefix overlap) to catch the common
-// nickname-vs-formal-name drift between Salesforce and Linear:
-//
-//   roster: "Robert Linsmayer"
-//   ticket: "Requested By: Rob Linsmayer"   → both should match
-//
-// The fuzzy rule requires both:
-//   • last word matches exactly (case-insensitive)
-//   • one first word is a prefix of the other and ≥ 2 chars
-// so "Rob Linsmayer" ↔ "Robert Linsmayer" matches but
-// "Robert Smith"   ↔ "Robert Jones"      does not.
-function findBucketForAE(byAE, aeName) {
-  const exactKey = normalizeName(aeName);
-  if (!exactKey || !byAE) return null;
-  if (byAE[exactKey]) return byAE[exactKey];
+// The three series rendered per SE group, in draw order (left→right).
+// Each `key` matches a field on the computed pack rows and a `--{key}`
+// color modifier in the LESS.
+const CHART_SERIES = [
+  { key: 'creation', label: 'Creation' },
+  { key: 'scoping', label: 'Scoping' },
+  { key: 'completed', label: 'Completed' },
+];
 
-  const aeParts = exactKey.split(/\s+/).filter(Boolean);
-  if (aeParts.length < 2) return null;
-  const aeFirst = aeParts[0];
-  const aeLast = aeParts[aeParts.length - 1];
+// Human labels + accent class for each closed-ticket category the
+// backend classifier emits. Shared by the drill-down ticket-list chips
+// so the categories read the same as the chart legend.
+const CATEGORY_META = {
+  creation: { label: 'Creation', cls: 'creation' },
+  estimation: { label: 'Scoping', cls: 'scoping' },
+  aiDemo: { label: 'AI Demo', cls: 'aidemo' },
+  other: { label: 'Other', cls: 'other' },
+};
 
-  for (const [key, bucket] of Object.entries(byAE)) {
-    const parts = key.split(/\s+/).filter(Boolean);
-    if (parts.length < 2) continue;
-    if (parts[parts.length - 1] !== aeLast) continue;
-    const candidateFirst = parts[0];
-    const minLen = Math.min(aeFirst.length, candidateFirst.length);
-    if (minLen < 2) continue;
-    const a = aeFirst.slice(0, minLen);
-    const b = candidateFirst.slice(0, minLen);
-    if (a === b) return bucket;
-  }
-  return null;
-}
-
-// Decide whether an opp counts as a "C-scored" deal that should be
-// excluded from CARR goal math. We key off **Account Score** rather
-// than Sales Score because ICP signals (AAR, geo, engineer count,
-// etc.) can promote an opp from Sales=C to Account=E — those E deals
-// should still count toward the goal. Empty `accountScore` (legacy
-// 2025 reports + pre-2026 snapshots) returns false, which keeps
-// historical years' totals identical to what they were before this
-// feature shipped.
-function isCScore(opp) {
-  const raw = (opp?.accountScore || '').trim().toUpperCase();
-  return raw === 'C' || raw.startsWith('C ') || raw.startsWith('C-');
-}
-
-/**
- * Walk every closed-won opp in the metrics payload and bucket them by
- * AE name (case-insensitive, whitespace-trimmed — same comparison the
- * backend uses in `userMetricsFilter.js` for SE-scoped views), routing
- * C-scored deals into a separate map so the team page can show them
- * under their own panel without polluting the goal-eligible totals.
- *
- * Returns `{ goalEligibleByAE, cScoreByAE }`, each Map<aeKey, Opp[]>
- * sorted by effective date desc (most recent close first).
- */
-function groupOppsByAE(data) {
-  const goalEligibleByAE = new Map();
-  const cScoreByAE = new Map();
-  if (!data) return { goalEligibleByAE, cScoreByAE };
-  // Prefer the flat list when present; the per-quarter buckets are the
-  // same source of truth either way.
-  const opps = Array.isArray(data.allOpportunities)
-    ? data.allOpportunities
-    : Object.entries(data.quarterlyData || {})
-        .filter(([key]) => key !== 'Total')
-        .flatMap(([, q]) => q?.opportunities ?? []);
-
-  for (const opp of opps) {
-    const key = normalizeName(opp.aeName);
-    if (!key) continue;
-    const target = isCScore(opp) ? cScoreByAE : goalEligibleByAE;
-    if (!target.has(key)) target.set(key, []);
-    target.get(key).push(opp);
-  }
-
-  const sortByDateDesc = (a, b) => {
-    const da = a.effectiveDate ? Date.parse(a.effectiveDate) : 0;
-    const db = b.effectiveDate ? Date.parse(b.effectiveDate) : 0;
-    return db - da;
-  };
-  for (const list of goalEligibleByAE.values()) list.sort(sortByDateDesc);
-  for (const list of cScoreByAE.values()) list.sort(sortByDateDesc);
-
-  return { goalEligibleByAE, cScoreByAE };
-}
-
-// Format a CARR amount as "$48,000" with no decimals — matches the
-// home-page metric tiles' compact treatment instead of the report's
-// raw "$48,000.00" string. Falls back to the formatted label from
-// the report when the numeric amount is missing.
-function formatCarr(opp) {
-  const amount = Number(opp?.carrAmount);
-  if (Number.isFinite(amount) && amount > 0) {
-    return `$${Math.round(amount).toLocaleString('en-US')}`;
-  }
-  return opp?.carrAmountFormatted || '—';
-}
-
-// Sum the numeric CARR for a list of opps. Skips rows whose carrAmount
-// is missing or non-numeric instead of poisoning the total with NaN.
-function sumCarr(opps) {
-  return opps.reduce((sum, opp) => {
-    const amount = Number(opp?.carrAmount);
-    return Number.isFinite(amount) ? sum + amount : sum;
-  }, 0);
-}
-
-function formatTotalCarr(amount) {
-  return `$${Math.round(amount).toLocaleString('en-US')}`;
-}
-
-// Compact currency for the at-a-glance summary tiles — matches the
-// home-page `CurrentQuarterMetrics` widget's formatting so the team
-// page's tiles read identically ($1.21M / $151K / $48,000).
-function formatCompactCurrency(amount) {
-  if (!Number.isFinite(amount) || amount <= 0) return '$0';
-  if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(2)}M`;
-  if (amount >= 1_000) return `$${(amount / 1_000).toFixed(0)}K`;
-  return `$${Math.round(amount).toLocaleString('en-US')}`;
-}
-
-// Build the report's quarter key for "right now" — e.g. "Q2 CY2026".
-// Mirrors the format the metrics report uses internally so we can
-// filter `opp.quarter` directly without any further normalization.
-function getCurrentQuarterKey() {
-  const now = new Date();
-  const month = now.getMonth() + 1;
-  const year = now.getFullYear();
-  const quarter = month <= 3 ? 1 : month <= 6 ? 2 : month <= 9 ? 3 : 4;
-  return `Q${quarter} CY${year}`;
-}
-
-// Just the quarter number (1..4) for the current calendar month —
-// used to pick the default tab on the Monthly Breakdown section so
-// the SE lands on whichever quarter they're actively living in.
-function getCurrentQuarterNumber() {
-  const month = new Date().getMonth() + 1;
-  return month <= 3 ? 1 : month <= 6 ? 2 : month <= 9 ? 3 : 4;
-}
-
-// Mirror of the backend's `quarterKeyOfDate` so the frontend can
-// re-bucket the unassigned ticket list by createdAt when the page is
-// in current-quarter scope. UTC math matches the backend so a
-// late-night ticket doesn't bucket differently here than on the
-// server.
-function quarterKeyOfDate(dateString) {
+// Map a Linear `completedAt` ISO date to the report's quarter key
+// ("Q2 CY2026") so the drill-down ticket list can be filtered to the
+// active quarter the same way the headline tiles are.
+function quarterKeyOf(dateString) {
   if (!dateString) return null;
   const d = new Date(dateString);
   if (Number.isNaN(d.getTime())) return null;
   const month = d.getUTCMonth() + 1;
-  const year = d.getUTCFullYear();
   const quarter = month <= 3 ? 1 : month <= 6 ? 2 : month <= 9 ? 3 : 4;
-  return `Q${quarter} CY${year}`;
+  return `Q${quarter} CY${d.getUTCFullYear()}`;
 }
 
-// Short label rendered next to the "Current Quarter" filter pill —
-// makes it obvious *which* quarter is being shown without forcing
-// the user to do calendar math.
-function getCurrentQuarterShortLabel() {
-  const key = getCurrentQuarterKey();
-  // "Q2 CY2026" → "Q2 2026"
-  return key.replace(/\s+CY/, ' ');
+// Format an ISO date as a short "Apr 28" label for the ticket rows.
+function formatShortDate(dateString) {
+  if (!dateString) return '';
+  const d = new Date(dateString);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
 }
 
-const SCOPE_YEAR = 'year';
-const SCOPE_QUARTER = 'quarter';
+// Whole-day difference between a "YYYY-MM-DD" due date and today, treating
+// both as calendar dates (no time-of-day). Negative = overdue. Linear due
+// dates are date-only and parse as UTC midnight, so we compare against
+// today's local calendar date pinned to the same UTC-midnight basis.
+function daysUntil(dateString) {
+  const due = new Date(dateString);
+  if (Number.isNaN(due.getTime())) return null;
+  const now = new Date();
+  const todayMs = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  const dueMs = Date.UTC(due.getUTCFullYear(), due.getUTCMonth(), due.getUTCDate());
+  return Math.round((dueMs - todayMs) / 86400000);
+}
 
-// Primary view toggle values. Kept as constants so the React state
-// initial value, the toggle handler, and the conditional render
-// branches all reference the same string instead of stringly-typed
-// magic literals scattered through the JSX.
-const VIEW_TEAM = 'team';
-const VIEW_YOU = 'you';
+// Build the due-date label + urgency tone for a ticket row. Open tickets
+// get relative wording ("Due today", "Due in 3 days", "Overdue") when the
+// deadline is near; everything else (and all closed tickets) falls back to
+// the absolute "Due Apr 28" form.
+function describeDue(dateString, relative) {
+  const abs = formatShortDate(dateString);
+  if (!abs) return null;
+  if (!relative) return { text: `Due ${abs}`, tone: 'default' };
+  const days = daysUntil(dateString);
+  if (days === null) return { text: `Due ${abs}`, tone: 'default' };
+  if (days < 0) return { text: 'Overdue', tone: 'overdue' };
+  if (days === 0) return { text: 'Due today', tone: 'today' };
+  if (days === 1) return { text: 'Due tomorrow', tone: 'soon' };
+  if (days <= 3) return { text: `Due in ${days} days`, tone: 'soon' };
+  return { text: `Due ${abs}`, tone: 'default' };
+}
 
-// Feature flag: "Tickets created broken down by AE" section. The
-// backend endpoint, classifier fixes, and Linear extraction work are
-// all live in main, but the UI is paused while the data quality
-// (Slack-bot attribution drift, AE field naming variance, nickname
-// matching) is being shaken out on a follow-up branch. Flip this to
-// `true` to re-enable the section without touching anything else —
-// fetch effect, memos, and JSX all read from the same constant so
-// the network call is also skipped while the flag is off.
-const SHOW_TICKETS_BY_AE = false;
+// Map a Linear workflow-state name to a color tone for its status pill.
+// Keyword-matched (rather than exact) so custom/renamed states still land
+// in a sensible bucket; unknown states fall back to a neutral pill.
+function statusTone(status) {
+  const s = (status || '').toLowerCase();
+  if (!s) return 'default';
+  if (/cancel/.test(s)) return 'canceled';
+  if (/(done|complete|shipped|merged|closed)/.test(s)) return 'done';
+  if (/(block|stuck|wait|hold|paused)/.test(s)) return 'blocked';
+  if (/(review|qa|testing)/.test(s)) return 'review';
+  if (/(progress|doing|started|active|build)/.test(s)) return 'progress';
+  if (/(todo|to do|ready|unstarted)/.test(s)) return 'todo';
+  if (/(backlog|triage)/.test(s)) return 'backlog';
+  return 'default';
+}
 
-// Category roster for the You-view monthly chart. One line per
-// entry; each entry drives both the line/dot color (via the
-// `--{key}` modifier in the LESS) and the legend pill. Order is
-// stable across renders so legend ordering matches what the eye
-// scans across the chart.
-const CHART_CATEGORIES = [
-  { key: 'creation', label: 'Creation' },
-  { key: 'estimation', label: 'Estimation' },
-  { key: 'aiDemo', label: 'AI Demo' },
-  { key: 'other', label: 'Other' },
-];
-
-// Chart geometry. ViewBox is fixed in user-space units (CSS scales
-// the SVG to fill its container while preserving aspect ratio), so
-// any tweaks here automatically reflow without touching the JSX.
-const CHART_VIEWBOX_W = 720;
-const CHART_VIEWBOX_H = 280;
-const CHART_PAD = { top: 20, right: 24, bottom: 40, left: 44 };
-
-// Round the data max up to a "nice" y-axis ceiling so tick marks
-// land on whole numbers (5/10/20/…) rather than on awkward
-// fractions like 9 or 13. Ensures we never show "7.25 tickets" on
-// a gridline. Floors at 5 so a quarter with a single ticket still
-// has room above the dot to breathe.
+// Round the data max up to a "nice" y-axis ceiling so tick marks land
+// on whole numbers rather than awkward fractions. Floors at 5 so a
+// pack with a single ticket still has headroom above the bar.
 function niceChartMax(value) {
   const v = Math.max(1, Math.ceil(value));
   if (v <= 5) return 5;
@@ -331,11 +179,8 @@ function niceChartMax(value) {
   return Math.ceil(v / 50) * 50;
 }
 
-// Build the {0, 25%, 50%, 75%, 100%} ladder of y-axis values, but
-// snapped to integers when the ceiling is small enough that
-// fractional gridlines would look weird. For yMax=5 we end up with
-// [0,1,2,3,4,5]; for yMax=10 we get [0,2,4,6,8,10]; for larger
-// values we fall back to 5 evenly-spaced ticks.
+// Integer y-axis ladder snapped so small ceilings don't show fractional
+// gridlines. yMax=5 → [0..5]; yMax=10 → [0,2,4,6,8,10]; larger → 5 ticks.
 function buildYTicks(yMax) {
   if (yMax <= 5) {
     return Array.from({ length: yMax + 1 }, (_, i) => i);
@@ -343,259 +188,579 @@ function buildYTicks(yMax) {
   if (yMax <= 10) {
     return [0, 2, 4, 6, 8, 10].filter((v) => v <= yMax);
   }
-  // 5 evenly-spaced ticks rounded to the nearest integer.
   return [0, 0.25, 0.5, 0.75, 1].map((p) => Math.round(p * yMax));
 }
 
-// Pretty-format an average lead time (days) for the ticket tile hint.
-// Adapts the unit to the magnitude so a "0.04 days" doesn't render as
-// the meaningless "0.0 days" — sub-day averages flip to hours, and
-// large averages drop the decimal so the caption stays compact.
-function formatAvgLeadTime(days) {
-  if (days == null || !Number.isFinite(days)) return null;
-  if (days < 1) {
-    const hours = days * 24;
-    if (hours < 1) return 'avg < 1h to close';
-    return `avg ${Math.round(hours)}h to close`;
+// A single ticket row in the drill-down list: a category chip, the title
+// (deep-linked to Linear when a URL is present), the project, and an
+// optional date (completion date for closed tickets).
+function TicketRow({ ticket, dateLabel, dueRelative }) {
+  const meta = CATEGORY_META[ticket.category] || CATEGORY_META.other;
+  const due = describeDue(ticket.dueDate, dueRelative);
+  return (
+    <li className="team-tickets__row">
+      <span className={`team-tickets__chip team-tickets__chip--${meta.cls}`}>{meta.label}</span>
+      <div className="team-tickets__main">
+        {ticket.url ? (
+          <a className="team-tickets__title" href={ticket.url} target="_blank" rel="noreferrer">
+            <span className="team-tickets__title-text">{ticket.title}</span>
+            <LuExternalLink className="team-tickets__title-icon" aria-hidden="true" />
+          </a>
+        ) : (
+          <span className="team-tickets__title">
+            <span className="team-tickets__title-text">{ticket.title}</span>
+          </span>
+        )}
+        {ticket.project && <span className="team-tickets__project">{ticket.project}</span>}
+      </div>
+      <div className="team-tickets__side">
+        {ticket.status && (
+          <span
+            className={`team-tickets__status team-tickets__status--${statusTone(ticket.status)}`}
+          >
+            {ticket.status}
+          </span>
+        )}
+        {due && (
+          <span className={`team-tickets__due team-tickets__due--${due.tone}`}>
+            <LuCalendar className="team-tickets__due-icon" aria-hidden="true" />
+            {due.text}
+          </span>
+        )}
+        {dateLabel && <span className="team-tickets__date">{dateLabel}</span>}
+      </div>
+    </li>
+  );
+}
+
+// Does a ticket pass the active column filters? Pure so it can be used
+// inside memo selectors without becoming a dependency itself.
+function ticketMatchesFilters(t, f) {
+  if (f.category && (t.category || 'other') !== f.category) return false;
+  if (f.project && t.project !== f.project) return false;
+  if (f.status && t.status !== f.status) return false;
+  if (f.q && !(t.title || '').toLowerCase().includes(f.q.trim().toLowerCase())) return false;
+  return true;
+}
+
+// Hide all-day blocks that aren't out-of-office (focus time, "Home",
+// lunch, etc.) — mirrors the dashboard's own calendar card so the team
+// drill-down reads the same way. OOO blocks are kept so a lead can spot
+// who's out today.
+function isVisibleCalendarEvent(ev) {
+  if (ev?.isAllDay && !ev?.isOoo) return false;
+  return true;
+}
+
+// Today's calendar for the drilled-into SE. Reuses the global
+// `dashboard-calendar` styles so it matches the homepage calendar card.
+// Soft states: loading, not-connected (SE hasn't linked Google), empty.
+function SeCalendar({ payload, error }) {
+  if (error) {
+    return (
+      <p className="team-page__linear-hint">
+        Couldn&apos;t load this SE&apos;s calendar right now.
+      </p>
+    );
   }
-  if (days < 10) return `avg ${days.toFixed(1)} days to close`;
-  return `avg ${Math.round(days)} days to close`;
+  if (!payload) {
+    return <p className="team-page__linear-hint">Loading calendar…</p>;
+  }
+  const firstName = payload.name?.split(/\s+/)[0] || 'This SE';
+  if (!payload.configured) {
+    return (
+      <p className="team-page__linear-hint">
+        {firstName} hasn&apos;t connected their Google Calendar.
+      </p>
+    );
+  }
+  const events = (payload.events || []).filter(isVisibleCalendarEvent);
+  if (events.length === 0) {
+    return <p className="team-page__linear-hint">No events scheduled today.</p>;
+  }
+  return (
+    <div className="dashboard-calendar">
+      {events.map((ev) => (
+        <div key={ev.id} className="dashboard-calendar__item">
+          <span className="dashboard-calendar__dot" style={{ background: ev.color }} aria-hidden />
+          <div className="dashboard-calendar__body">
+            <p className="dashboard-calendar__heading">
+              <span className="dashboard-calendar__time">{ev.time}</span>
+              <span className="dashboard-calendar__title">{ev.title}</span>
+            </p>
+            <p className="dashboard-calendar__meta">{ev.meta}</p>
+          </div>
+          {(ev.attendeeCount > 0 || ev.videoUrl) && (
+            <div className="dashboard-calendar__row-actions">
+              {ev.attendeeCount > 0 && (
+                <span
+                  className="dashboard-calendar__chip"
+                  title={`${ev.attendeeCount} ${ev.attendeeCount === 1 ? 'attendee' : 'attendees'}`}
+                >
+                  {ev.attendeeCount}
+                </span>
+              )}
+              {ev.videoUrl && (
+                <a
+                  className="dashboard-calendar__join"
+                  href={ev.videoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={ev.videoProvider ? `Join via ${ev.videoProvider}` : 'Join video call'}
+                >
+                  Join
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// The two ticket lists shown beneath the headline tiles in the drill-down:
+// the SE's live open workload and the tickets they completed in the active
+// scope. Owns a column filter bar (title search + category / project /
+// status) that narrows both lists at once, plus its own loading / error /
+// empty states so the parent JSX stays flat.
+function TicketLists({ error, loaded, open, closed, periodLabel }) {
+  // The completed list can get long, so it's a collapsible disclosure the
+  // lead can fold away. Defaults open; collapsing is purely cosmetic.
+  const [closedExpanded, setClosedExpanded] = useState(true);
+  const [filters, setFilters] = useState({ q: '', category: '', project: '', status: '' });
+
+  // Dropdown options, derived from the union of both lists so a value the
+  // lead picks always matches at least one row somewhere on the page.
+  const options = useMemo(() => {
+    const all = [...open, ...closed];
+    const seenCat = new Set();
+    const categories = [];
+    for (const t of all) {
+      const key = t.category || 'other';
+      if (!seenCat.has(key)) {
+        seenCat.add(key);
+        categories.push({ value: key, label: (CATEGORY_META[key] || CATEGORY_META.other).label });
+      }
+    }
+    const uniq = (vals) =>
+      Array.from(new Set(vals.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+    return {
+      categories: categories.sort((a, b) => a.label.localeCompare(b.label)),
+      projects: uniq(all.map((t) => t.project)),
+      statuses: uniq(all.map((t) => t.status)),
+    };
+  }, [open, closed]);
+
+  const filteredOpen = useMemo(
+    () => open.filter((t) => ticketMatchesFilters(t, filters)),
+    [open, filters],
+  );
+  const filteredClosed = useMemo(
+    () => closed.filter((t) => ticketMatchesFilters(t, filters)),
+    [closed, filters],
+  );
+
+  if (error) {
+    return (
+      <p className="team-page__linear-hint">
+        Couldn&apos;t load this SE&apos;s tickets right now. Try refreshing in a minute.
+      </p>
+    );
+  }
+  if (!loaded) {
+    return <p className="team-page__linear-hint">Loading tickets…</p>;
+  }
+
+  const closedHeading = `Completed in ${periodLabel}`;
+
+  const setFilter = (key, value) => setFilters((f) => ({ ...f, [key]: value }));
+  const anyActive = Boolean(filters.q || filters.category || filters.project || filters.status);
+
+  return (
+    <div className="team-tickets">
+      <div className="team-tickets__filters">
+        <input
+          type="search"
+          className="team-tickets__search"
+          placeholder="Search title…"
+          aria-label="Search ticket titles"
+          value={filters.q}
+          onChange={(e) => setFilter('q', e.target.value)}
+        />
+        <select
+          className="team-tickets__select"
+          aria-label="Filter by category"
+          value={filters.category}
+          onChange={(e) => setFilter('category', e.target.value)}
+        >
+          <option value="">All categories</option>
+          {options.categories.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+        <select
+          className="team-tickets__select"
+          aria-label="Filter by project"
+          value={filters.project}
+          onChange={(e) => setFilter('project', e.target.value)}
+        >
+          <option value="">All projects</option>
+          {options.projects.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <select
+          className="team-tickets__select"
+          aria-label="Filter by status"
+          value={filters.status}
+          onChange={(e) => setFilter('status', e.target.value)}
+        >
+          <option value="">All statuses</option>
+          {options.statuses.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        {anyActive && (
+          <button
+            type="button"
+            className="team-tickets__clear"
+            onClick={() => setFilters({ q: '', category: '', project: '', status: '' })}
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      <section className="team-tickets__group">
+        <h3 className="team-tickets__heading">
+          Open workload <span className="team-tickets__count">{filteredOpen.length}</span>
+        </h3>
+        {open.length === 0 ? (
+          <p className="team-tickets__empty">Nothing open right now.</p>
+        ) : filteredOpen.length === 0 ? (
+          <p className="team-tickets__empty">No open tickets match these filters.</p>
+        ) : (
+          <ul className="team-tickets__list">
+            {filteredOpen.map((t) => (
+              <TicketRow key={t.id} ticket={t} dateLabel={null} dueRelative />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="team-tickets__group">
+        <button
+          type="button"
+          className="team-tickets__toggle"
+          aria-expanded={closedExpanded}
+          onClick={() => setClosedExpanded((v) => !v)}
+        >
+          <LuChevronDown
+            className={`team-tickets__toggle-icon ${closedExpanded ? 'is-open' : ''}`}
+            aria-hidden="true"
+          />
+          <span className="team-tickets__heading-text">{closedHeading}</span>
+          <span className="team-tickets__count">{filteredClosed.length}</span>
+        </button>
+        {closedExpanded &&
+          (closed.length === 0 ? (
+            <p className="team-tickets__empty">No completed tickets in this window.</p>
+          ) : filteredClosed.length === 0 ? (
+            <p className="team-tickets__empty">No completed tickets match these filters.</p>
+          ) : (
+            <ul className="team-tickets__list">
+              {filteredClosed.map((t) => (
+                <TicketRow key={t.id} ticket={t} dateLabel={formatShortDate(t.completedAt)} />
+              ))}
+            </ul>
+          ))}
+      </section>
+    </div>
+  );
 }
 
 /**
- * TeamPage - per-SE landing page ("Team Mario", "Team Yoshi", ...).
+ * TeamPage — the lead's "Pack" overview ("Team Mario", "Team Yoshi", …).
  *
- * Scope is intentionally "own team only" for now: each SE only ever sees
- * their own team's page. The :slug in the URL is cosmetic — if it doesn't
- * match the logged-in SE's team we redirect to the canonical slug instead
- * of 404'ing, so a stale bookmark or hand-typed URL still lands somewhere
- * useful.
- *
- * Visually the page borrows from The Den (the dashboard) without copying
- * the data: same `.page-header` heading treatment, same `.dashboard-panel`
- * panel surface and `.dashboard-widgets` grid layout. The body is one
- * panel per AE on the SE's team, with the AE's name as the panel title
- * and a row per closed-won opp underneath (Opportunity name + CARR).
+ * Renders a grouped bar chart of every active Sales Engineer's Creation /
+ * Scoping / Completed Linear tickets, scoped to the whole year or the
+ * current quarter. Clicking an SE's bar group drills into a high-level
+ * detail panel (their live workload + closed breakdown). Lead/admin only;
+ * the backend endpoint that feeds it is gated to the same roles. The :slug
+ * in the URL is cosmetic — a mismatch redirects to the canonical slug.
  */
 function TeamPage() {
   const { user } = useAuth();
   const { slug } = useParams();
   const team = user?.team;
-  // First-name only for the personalized "Tickets closed by you" copy.
-  // Pulled off the auth user, falls back to empty string so the
-  // subtitle reads naturally ("Linear tickets you've completed…")
-  // when we can't resolve a name.
-  const firstName = useMemo(() => {
-    const raw = (user?.name || '').trim();
-    if (!raw) return '';
-    return raw.split(/\s+/)[0];
-  }, [user?.name]);
 
-  // Salesforce metrics state. Reads from the shared localStorage cache
-  // first so the page paints instantly when the SE has already hit
-  // The Den, then refreshes in the background.
-  const [config, setConfig] = useState(readCachedConfig);
-  const [data, setData] = useState(null);
-  const [error, setError] = useState(null);
-  const [loading, setLoading] = useState(true);
+  // Leads (and admins) get the pack overview. Regular SEs see a short
+  // note instead — the backend endpoint is gated to the same roles, so
+  // this is a UX convenience rather than the security boundary.
+  const isLead = useMemo(() => {
+    const roles = user?.roles || [];
+    return roles.includes('admin') || roles.includes('sales_engineer_lead');
+  }, [user?.roles]);
 
-  // Year / Current-Quarter scope filter. Default to year so the page
-  // matches what a fresh visitor saw before the filter was added; the
-  // filter narrows down rather than expanding away from a default.
-  const [scope, setScope] = useState(SCOPE_YEAR);
+  // Scope controls: which calendar year to load, and whether to show the
+  // full year (quarter === 0) or a single quarter (1-4).
+  const [selectedYear, setSelectedYear] = useState(getCurrentYear());
+  const [quarter, setQuarter] = useState(0);
 
-  // Primary view toggle: "team" shows the SF roll-up + AE breakdown,
-  // "you" shows the personal Linear tickets section. We default to
-  // "team" because the team page's mental model is "this is my team's
-  // page" — the personal view is one click away when an SE wants to
-  // zoom into their own contribution.
-  const [view, setView] = useState(VIEW_TEAM);
+  // Derived once per render and threaded through the memos / labels below.
+  const quarterKey = buildQuarterKey(selectedYear, quarter);
+  const periodLabel = buildPeriodLabel(selectedYear, quarter);
 
-  // Selected quarter for the You-view "Monthly breakdown" section.
-  // Independent of the year/quarter filter pill — the filter pill
-  // rescopes the topline tiles, while this picks which quarter the
-  // chart below renders. Defaults to whichever quarter contains today.
-  const [selectedQuarter, setSelectedQuarter] = useState(getCurrentQuarterNumber);
+  // Pack payload (per-SE roll-up) and error state.
+  const [packData, setPackData] = useState(null);
+  const [packError, setPackError] = useState(null);
 
-  // Personal Linear roll-up (tickets THIS user has closed). Independent
-  // of the Salesforce metrics fetch — different data source, different
-  // failure modes — but driven by the same `scope` so toggling the
-  // filter pill rescopes both halves of the page in lock-step. Tiles
-  // render "—" while the request is in flight (no separate loading
-  // flag needed) to mirror the SF tile loading behaviour below.
-  const [linearClosed, setLinearClosed] = useState(null);
-  const [linearError, setLinearError] = useState(null);
+  // Per-SE Closed CARR roll-up (Salesforce, attributed via handoff pages).
+  const [packCarr, setPackCarr] = useState(null);
+
+  // When set, the chart is replaced by a high-level detail panel for the
+  // chosen SE (their workload + closed breakdown). Cleared by the "back"
+  // button. All the numbers come from the pack payload already in memory,
+  // so drilling in costs no extra request.
+  const [selectedSeId, setSelectedSeId] = useState(null);
+
+  // Actual Linear tickets (open + closed-this-year) for the drilled-into
+  // SE. Fetched lazily the first time a row is opened; the closed list is
+  // filtered down to the active quarter client-side when the quarter pill
+  // is on, so we only ever hit the endpoint once per SE.
+  const [seTickets, setSeTickets] = useState(null);
+  const [seTicketsError, setSeTicketsError] = useState(null);
+
+  // Today's calendar for the drilled-into SE. Fetched lazily per SE; not
+  // year-scoped (always "today"), so it only depends on the selection.
+  const [seCalendar, setSeCalendar] = useState(null);
+  const [seCalendarError, setSeCalendarError] = useState(null);
 
   useEffect(() => {
-    let cancelled = false;
-    setLinearError(null);
-    fetchDashboardLinearClosed()
-      .then((payload) => {
-        if (cancelled) return;
-        setLinearClosed(payload);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setLinearError(err?.message || 'Failed to load Linear tickets');
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Team-wide tickets-created-by-AE rollup. Powers the "Tickets created
-  // broken down by AE" section on the Team view: per-AE counts of
-  // tickets each AE has submitted this year, broken into Creation /
-  // Estimation / AI Demo. Independent fetch from the personal closed
-  // rollup above — different shape, different scope — but soft-fails
-  // the same way (the section just shows a hint instead of failing
-  // the whole page).
-  const [ticketsByAE, setTicketsByAE] = useState(null);
-  const [ticketsByAEError, setTicketsByAEError] = useState(null);
-
-  useEffect(() => {
-    // Gated by the same flag the JSX section below is gated on, so a
-    // disabled feature doesn't waste a Linear round-trip on every
-    // team-page mount. Re-enable the section by flipping
-    // `SHOW_TICKETS_BY_AE` to `true` and the fetch wakes back up.
-    if (!SHOW_TICKETS_BY_AE) return undefined;
-    let cancelled = false;
-    setTicketsByAEError(null);
-    fetchDashboardLinearTicketsByAE()
-      .then((payload) => {
-        if (cancelled) return;
-        setTicketsByAE(payload);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setTicketsByAEError(err?.message || 'Failed to load tickets by AE');
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Apply the same year / current-quarter scope to the Linear roll-up
-  // that we apply to the SF roster, so the page tells one coherent
-  // story under whichever filter is active.
-  const closedTicketsScoped = useMemo(() => {
-    if (!linearClosed?.configured) return null;
-    if (scope === SCOPE_QUARTER) {
-      const currentKey = getCurrentQuarterKey();
-      return (
-        linearClosed.byQuarter?.[currentKey] ?? {
-          estimation: 0,
-          creation: 0,
-          aiDemo: 0,
-          other: 0,
-          total: 0,
-        }
-      );
-    }
-    return linearClosed.total;
-  }, [linearClosed, scope]);
-
-  // Quarter bucket the Monthly Breakdown chart is currently rendering.
-  // Decoupled from the filter pill — that pill rescopes the topline
-  // tiles, while this section has its own quarter tab strip below.
-  const selectedQuarterBucket = useMemo(() => {
-    if (!linearClosed?.configured) return null;
-    const year = linearClosed.year;
-    const key = `Q${selectedQuarter} CY${year}`;
-    return linearClosed.byQuarter?.[key] ?? null;
-  }, [linearClosed, selectedQuarter]);
-
-  const currentYear = useMemo(() => resolveDataYear(config), [config]);
-
-  // Hydrate `data` from cache the moment we know which year to read,
-  // so the first paint already shows opps if the user just came from
-  // The Den (which writes the same cache key).
-  useEffect(() => {
-    const cached = readCachedData(currentYear);
-    if (cached) {
-      setData(cached);
-      setLoading(false);
-    }
-  }, [currentYear]);
-
-  // Refresh config in the background. Same pattern as
-  // CurrentQuarterMetrics — silent failures, best-effort cache write.
-  useEffect(() => {
-    let cancelled = false;
-    getSalesforceConfig()
-      .then((c) => {
-        if (cancelled) return;
-        setConfig(c);
-        try {
-          localStorage.setItem(CONFIG_CACHE_KEY, JSON.stringify(c));
-        } catch {
-          // ignore cache write issues
-        }
-      })
-      .catch(() => {
-        if (!cancelled && !readCachedConfig()) {
-          setError('Failed to load Salesforce config');
-          setLoading(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Fetch (or refresh) the metrics report for the resolved year. Falls
-  // back to the live report endpoint when the year isn't snapshotted.
-  useEffect(() => {
-    if (!config) return undefined;
-    const isSnapshotYear = (config.snapshotYears || []).includes(currentYear);
-    const reportId = config.reportIdsByYear?.[currentYear]?.metrics;
-    if (!isSnapshotYear && !reportId) {
-      setLoading(false);
+    if (!selectedSeId) {
+      setSeTickets(null);
+      setSeTicketsError(null);
       return undefined;
     }
-
     let cancelled = false;
-    // We always flip loading on while a refetch is in flight; the render
-    // branches show the cached opp list whenever `data` is truthy
-    // regardless of `loading`, so this doesn't cause a visible flicker
-    // on warm caches. Avoids reading `data` inside the effect (which
-    // would either need to be a dep or be silenced).
-    setLoading(true);
-    setError(null);
-
-    const fetchMetrics = () => {
-      if (isSnapshotYear) {
-        return fetchSalesforceSnapshotMetrics(currentYear).catch(() => {
-          if (reportId) return fetchSalesforceReport(reportId);
-          throw new Error('Snapshot unavailable and no report ID for this year');
-        });
-      }
-      return fetchSalesforceReport(reportId);
-    };
-
-    fetchMetrics()
-      .then((response) => {
-        if (cancelled) return;
-        setData(response);
-        setError(null);
-        writeCachedData(currentYear, response);
+    setSeTickets(null);
+    setSeTicketsError(null);
+    fetchPackSeTickets(selectedSeId, selectedYear)
+      .then((payload) => {
+        if (!cancelled) setSeTickets(payload);
       })
       .catch((err) => {
-        if (!cancelled) setError(err.message);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setSeTicketsError(err?.message || 'Failed to load tickets');
       });
-
     return () => {
       cancelled = true;
     };
-  }, [config, currentYear]);
+  }, [selectedSeId, selectedYear]);
+
+  // Pull the selected SE's today calendar. Soft state — a failure or an
+  // unconnected SE just renders a hint inside the panel.
+  useEffect(() => {
+    if (!selectedSeId) {
+      setSeCalendar(null);
+      setSeCalendarError(null);
+      return undefined;
+    }
+    let cancelled = false;
+    setSeCalendar(null);
+    setSeCalendarError(null);
+    fetchPackSeCalendar(selectedSeId)
+      .then((payload) => {
+        if (!cancelled) setSeCalendar(payload);
+      })
+      .catch((err) => {
+        if (!cancelled) setSeCalendarError(err?.message || 'Failed to load calendar');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedSeId]);
+
+  // Fetch the pack-wide roll-up once we know the viewer is a lead, scoped to
+  // the selected year. Refetches when the year changes; the quarter pill then
+  // slices the returned `byQuarter` buckets client-side. Soft-fails into a hint.
+  useEffect(() => {
+    if (!isLead) return undefined;
+    let cancelled = false;
+    setPackError(null);
+    fetchPackOverview(selectedYear)
+      .then((payload) => {
+        if (!cancelled) setPackData(payload);
+      })
+      .catch((err) => {
+        if (!cancelled) setPackError(err?.message || 'Failed to load pack overview');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isLead, selectedYear]);
+
+  // Pull the per-SE Closed CARR roll-up alongside the pack overview. Soft
+  // state only — CARR is a "nice to have" below the chart, so a failure or
+  // an unconfigured Salesforce year just hides the section rather than
+  // blocking the page.
+  useEffect(() => {
+    if (!isLead) return undefined;
+    let cancelled = false;
+    fetchPackCarr(selectedYear)
+      .then((payload) => {
+        if (!cancelled) setPackCarr(payload);
+      })
+      .catch(() => {
+        if (!cancelled) setPackCarr({ configured: false, sets: [] });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isLead, selectedYear]);
+
+  // One row per SE, scoped to the active pill and sorted by completed
+  // tickets descending so the chart reads left-to-right from most to
+  // least productive.
+  const packRows = useMemo(() => {
+    // Drop the viewing lead's own row — they're looking at the pack, not
+    // themselves. Match on the app user id the backend stamps onto each set.
+    const sets = (packData?.sets || []).filter((s) => s.userId !== user?.id);
+    const rows = sets.map((set) => {
+      const closed = quarterKey
+        ? set.closed?.byQuarter?.[quarterKey] || {}
+        : set.closed?.total || {};
+      return {
+        seId: set.seId,
+        name: set.name,
+        open: set.open || 0,
+        creation: closed.creation || 0,
+        scoping: closed.estimation || 0,
+        completed: closed.total || 0,
+      };
+    });
+    rows.sort((a, b) => b.completed - a.completed);
+    return rows;
+  }, [packData, quarterKey, user?.id]);
+
+  // Pack-wide totals across the displayed SEs (already lead-excluded and
+  // scoped to the active year/quarter), shown as summary cards above the
+  // chart.
+  const packTotals = useMemo(
+    () =>
+      packRows.reduce(
+        (acc, r) => ({
+          ses: acc.ses + 1,
+          open: acc.open + r.open,
+          creation: acc.creation + r.creation,
+          scoping: acc.scoping + r.scoping,
+          completed: acc.completed + r.completed,
+        }),
+        { ses: 0, open: 0, creation: 0, scoping: 0, completed: 0 },
+      ),
+    [packRows],
+  );
+
+  // Per-SE Closed CARR for the active scope, lead excluded, sorted high to
+  // low. `max` drives the proportional bar widths; `total` is the pack sum.
+  const carrBreakdown = useMemo(() => {
+    const rows = (packCarr?.sets || [])
+      .filter((s) => s.userId !== user?.id)
+      .map((s) => ({
+        seId: s.seId,
+        name: s.name,
+        carr: quarterKey ? s.byQuarter?.[quarterKey] || 0 : s.total || 0,
+      }))
+      .sort((a, b) => b.carr - a.carr);
+    const max = rows.reduce((m, r) => Math.max(m, r.carr), 0);
+    const total = rows.reduce((sum, r) => sum + r.carr, 0);
+    return { rows, max, total };
+  }, [packCarr, quarterKey, user?.id]);
+
+  // Pre-compute the SVG layout (bar rects, y-axis ticks, x labels) for
+  // the grouped bar chart. Bars are grouped by SE; within a group the
+  // three series sit side by side with a small gap.
+  const chartLayout = useMemo(() => {
+    const rows = packRows;
+    const plotW = CHART.w - CHART.padLeft - CHART.padRight;
+    const plotH = CHART.h - CHART.padTop - CHART.padBottom;
+    const baseY = CHART.padTop + plotH;
+    const maxVal = rows.reduce((m, r) => Math.max(m, r.creation, r.scoping, r.completed), 0);
+    const yMax = niceChartMax(maxVal);
+    const yTicks = buildYTicks(yMax);
+    const n = rows.length;
+    const groupW = n > 0 ? plotW / n : plotW;
+    const groupInner = groupW * 0.64;
+    const slotW = groupInner / CHART_SERIES.length;
+    const barW = slotW * 0.84;
+
+    const groups = rows.map((row, i) => {
+      const slotX = CHART.padLeft + i * groupW;
+      const x0 = slotX + (groupW - groupInner) / 2;
+      const bars = CHART_SERIES.map((s, j) => {
+        const val = row[s.key] || 0;
+        const h = yMax > 0 ? (val / yMax) * plotH : 0;
+        return {
+          key: s.key,
+          val,
+          x: x0 + j * slotW + (slotW - barW) / 2,
+          y: baseY - h,
+          w: barW,
+          h,
+        };
+      });
+      return {
+        seId: row.seId,
+        name: row.name,
+        label: row.name.split(/\s+/)[0],
+        cx: slotX + groupW / 2,
+        bars,
+      };
+    });
+
+    return { plotW, plotH, baseY, yMax, yTicks, groups };
+  }, [packRows]);
+
+  // High-level detail for the SE the lead clicked into. Pulls the same
+  // category breakdown the chart uses (plus AI Demo / Other), scoped by
+  // the active pill. Returns null when nothing is selected or the SE
+  // fell out of the payload on a refetch.
+  const selectedDetail = useMemo(() => {
+    if (!selectedSeId) return null;
+    const set = (packData?.sets || []).find((s) => s.seId === selectedSeId);
+    if (!set) return null;
+    const closed = quarterKey ? set.closed?.byQuarter?.[quarterKey] || {} : set.closed?.total || {};
+    return {
+      seId: set.seId,
+      name: set.name,
+      open: set.open || 0,
+      completed: closed.total || 0,
+      creation: closed.creation || 0,
+      scoping: closed.estimation || 0,
+      aiDemo: closed.aiDemo || 0,
+      other: closed.other || 0,
+    };
+  }, [selectedSeId, packData, quarterKey]);
+
+  // The closed tickets to actually list, narrowed to the current quarter
+  // when the quarter pill is active so the list stays in lockstep with
+  // the headline "Completed" tile above it. Open workload is always
+  // "right now", so it ignores the scope.
+  const visibleClosedTickets = useMemo(() => {
+    const closed = seTickets?.closed || [];
+    if (!quarterKey) return closed;
+    return closed.filter((t) => quarterKeyOf(t.completedAt) === quarterKey);
+  }, [seTickets, quarterKey]);
 
   // Split "Team Mario" → { prefix: "Team", rest: "Mario" } so the prefix
-  // can render in white and the actual identity (rest) can pop in coral,
-  // matching the way the dashboard hero renders the team chip. Single-
-  // word names just render the whole thing in coral.
+  // renders in white and the identity (rest) pops in coral, matching the
+  // dashboard hero. Single-word names render the whole thing in coral.
   const teamParts = useMemo(() => {
     const raw = team?.name?.trim();
     if (!raw) return null;
@@ -603,197 +768,6 @@ function TeamPage() {
     if (idx === -1) return { prefix: '', rest: raw };
     return { prefix: raw.slice(0, idx), rest: raw.slice(idx + 1) };
   }, [team?.name]);
-
-  // Bucket every opp into goal-eligible (A/B/E/...) vs C-scored. The
-  // team page renders these as two distinct sections — headline tiles
-  // and per-AE cards consume only the goal-eligible map; the new
-  // "Closed-won C opps" panel below the roster consumes the C map.
-  const { goalEligibleByAE, cScoreByAE } = useMemo(() => groupOppsByAE(data), [data]);
-
-  // Apply the year / current-quarter scope. When viewing the year the
-  // groupings pass through untouched; when viewing the current quarter
-  // we filter each AE's list to opps whose `quarter` matches today's
-  // quarter key (the same shape the metrics report writes, e.g.
-  // "Q2 CY2026"), so the totals + rows + counts all stay in lock-step.
-  const filteredOppsByAE = useMemo(() => {
-    if (scope === SCOPE_YEAR) return goalEligibleByAE;
-    const currentKey = getCurrentQuarterKey();
-    const next = new Map();
-    for (const [aeKey, opps] of goalEligibleByAE.entries()) {
-      next.set(
-        aeKey,
-        opps.filter((opp) => opp.quarter === currentKey),
-      );
-    }
-    return next;
-  }, [goalEligibleByAE, scope]);
-
-  // Same scope filter, applied to the C-scored bucket. Kept as a
-  // sibling memo (rather than parameterizing the one above) so each
-  // section renders from a stable reference and React doesn't
-  // re-render one panel just because the other's data churned.
-  const filteredCOppsByAE = useMemo(() => {
-    if (scope === SCOPE_YEAR) return cScoreByAE;
-    const currentKey = getCurrentQuarterKey();
-    const next = new Map();
-    for (const [aeKey, opps] of cScoreByAE.entries()) {
-      next.set(
-        aeKey,
-        opps.filter((opp) => opp.quarter === currentKey),
-      );
-    }
-    return next;
-  }, [cScoreByAE, scope]);
-
-  // Roll up team-wide stats from the same filtered map that drives the
-  // AE roster, restricted to the team's own AE roster so the at-a-glance
-  // tiles and the per-AE cards always tell a consistent story
-  // (sum of AE totals === team total, etc.).
-  //
-  // Previously this iterated `filteredOppsByAE.values()` directly, which
-  // included every AE bucket in the pack-wide payload — that meant teams
-  // whose AEs hadn't closed anything (e.g. Team Sonic on launch day) saw
-  // pack-wide pipeline numbers in the tiles but $0 per-AE in the cards.
-  const teamTotals = useMemo(() => {
-    const teamAEs = team?.accountExecutives ?? [];
-    let totalCarr = 0;
-    let count = 0;
-    for (const ae of teamAEs) {
-      const opps = filteredOppsByAE.get(normalizeName(ae.name)) ?? [];
-      for (const opp of opps) {
-        const amount = Number(opp?.carrAmount);
-        if (Number.isFinite(amount)) totalCarr += amount;
-        count += 1;
-      }
-    }
-    return {
-      totalCarr,
-      count,
-      avgDealSize: count > 0 ? totalCarr / count : 0,
-    };
-  }, [filteredOppsByAE, team?.accountExecutives]);
-
-  // Same roll-up shape, restricted to C-scored opps for the team's
-  // own AEs. Drives the C-section subtitle ("X opps · $Y") and the
-  // empty-state branch when the team has no C deals in scope.
-  const cTeamTotals = useMemo(() => {
-    const teamAEs = team?.accountExecutives ?? [];
-    let totalCarr = 0;
-    let count = 0;
-    for (const ae of teamAEs) {
-      const opps = filteredCOppsByAE.get(normalizeName(ae.name)) ?? [];
-      for (const opp of opps) {
-        const amount = Number(opp?.carrAmount);
-        if (Number.isFinite(amount)) totalCarr += amount;
-        count += 1;
-      }
-    }
-    return { totalCarr, count };
-  }, [filteredCOppsByAE, team?.accountExecutives]);
-
-  // Unassigned tickets (no AE field filled in), scoped the same way.
-  // The backend collects these into a single team-wide bucket; on
-  // year scope we read the totals, on quarter scope we slice the
-  // `byQuarter` map and filter the ticket list by createdAt so the
-  // disclosure stays consistent with the count above it.
-  const unassignedScoped = useMemo(() => {
-    const bucket = ticketsByAE?.unassigned;
-    if (!bucket) {
-      return {
-        total: 0,
-        estimation: 0,
-        creation: 0,
-        aiDemo: 0,
-        other: 0,
-        tickets: [],
-      };
-    }
-    if (scope === SCOPE_QUARTER) {
-      const currentKey = getCurrentQuarterKey();
-      const slice = bucket.byQuarter?.[currentKey] || {
-        total: 0,
-        estimation: 0,
-        creation: 0,
-        aiDemo: 0,
-        other: 0,
-      };
-      const tickets = (bucket.tickets || []).filter(
-        (t) => quarterKeyOfDate(t.createdAt) === currentKey,
-      );
-      return { ...slice, tickets };
-    }
-    return {
-      total: bucket.total || 0,
-      estimation: bucket.estimation || 0,
-      creation: bucket.creation || 0,
-      aiDemo: bucket.aiDemo || 0,
-      other: bucket.other || 0,
-      tickets: bucket.tickets || [],
-    };
-  }, [ticketsByAE, scope]);
-
-  // Per-AE tickets-created counts for the team's own AE roster, scoped
-  // to whichever window the page is showing (year vs current quarter).
-  // The backend returns `byAE` keyed by normalized name; we walk the
-  // team roster (so the order matches the CARR section above and AEs
-  // with zero submissions still render an empty card) and pull each
-  // AE's bucket out, falling back to a zero-bucket when there's no
-  // entry. Quarter scope reads the AE's `byQuarter[currentKey]` if
-  // present, otherwise zeros — same pattern as `closedTicketsScoped`.
-  const ticketsByAEScoped = useMemo(() => {
-    const teamAEs = team?.accountExecutives ?? [];
-    const map = ticketsByAE?.byAE || {};
-    const currentKey = scope === SCOPE_QUARTER ? getCurrentQuarterKey() : null;
-    return teamAEs.map((ae) => {
-      // Fuzzy lookup so nickname drift between Salesforce and Linear
-      // ("Rob" in a ticket vs "Robert" on the roster) doesn't drop
-      // the AE's count to zero — see `findBucketForAE` for the rule.
-      const bucket = findBucketForAE(map, ae.name);
-      const slice = currentKey
-        ? bucket?.byQuarter?.[currentKey] || {
-            total: 0,
-            estimation: 0,
-            creation: 0,
-            aiDemo: 0,
-            other: 0,
-          }
-        : bucket || {
-            total: 0,
-            estimation: 0,
-            creation: 0,
-            aiDemo: 0,
-            other: 0,
-          };
-      return {
-        ae,
-        total: slice.total || 0,
-        estimation: slice.estimation || 0,
-        creation: slice.creation || 0,
-        aiDemo: slice.aiDemo || 0,
-        other: slice.other || 0,
-      };
-    });
-  }, [ticketsByAE, scope, team?.accountExecutives]);
-
-  // Flat list of C opps for the team's own AEs, sorted by close date
-  // desc (most recent first). Each row carries `aeName` so the table
-  // renders Opp / AE / CARR side-by-side without the consumer having
-  // to walk the per-AE map again. The per-AE bucket already sorts by
-  // date desc, but merging across AEs requires resorting the union.
-  const cOppsForTeam = useMemo(() => {
-    const teamAEs = team?.accountExecutives ?? [];
-    const rows = [];
-    for (const ae of teamAEs) {
-      const opps = filteredCOppsByAE.get(normalizeName(ae.name)) ?? [];
-      for (const opp of opps) rows.push({ opp, aeName: ae.name });
-    }
-    rows.sort((a, b) => {
-      const da = a.opp.effectiveDate ? Date.parse(a.opp.effectiveDate) : 0;
-      const db = b.opp.effectiveDate ? Date.parse(b.opp.effectiveDate) : 0;
-      return db - da;
-    });
-    return rows;
-  }, [filteredCOppsByAE, team?.accountExecutives]);
 
   if (!team) {
     return (
@@ -811,16 +785,15 @@ function TeamPage() {
     return <Navigate to={`/teams/${canonicalSlug}`} replace />;
   }
 
-  const aes = team.accountExecutives ?? [];
   const mascot = TEAM_MASCOTS[canonicalSlug];
+
+  const selectSe = (seId) => setSelectedSeId(seId);
 
   return (
     <div className="dashboard">
       {/*
         Three-column hero: flexible spacer on the left, big centered
-        title in the middle, optional mascot pinned to the right. The
-        two 1fr edge columns balance so the title stays visually
-        centered regardless of whether the team has mascot artwork.
+        title in the middle, optional mascot pinned to the right.
       */}
       <header className="page-header team-page__hero">
         <h1 className="team-page__hero-title">
@@ -830,1051 +803,310 @@ function TeamPage() {
         {mascot && <img className="team-page__mascot" src={mascot.src} alt={mascot.alt} />}
       </header>
 
-      {aes.length === 0 ? (
-        <p className="page-header__sub">
-          No active AEs on this team yet. Ask an admin to add one in the Alpha Pack.
-        </p>
-      ) : (
-        // Body wrapper insets the content horizontally from the
-        // full-bleed hero above so the section reads as a nested
-        // zone. New sections (Pipeline, Activity, etc.) live as
-        // additional siblings inside this wrapper and inherit the
-        // same gutter for free.
-        <div className="team-page__body">
-          {/*
-            Page-level controls bar. Two segmented toggles share a row
-            so all the page-wide knobs live in one predictable spot at
-            the top of the body:
-              • "View" picks the section set below (Team vs You).
-              • "Scope" rescopes whichever sections are showing
-                (year vs current quarter).
-            Both controls follow whichever view is active — a quarter
-            scope on Team mode rescopes the SF roll-up; same scope on
-            You mode rescopes the Linear roll-up.
-          */}
-          <div className="team-page__controls">
-            <div
-              className="team-page__filter team-page__filter--view"
-              role="tablist"
-              aria-label="Switch between team and personal view"
-            >
-              <button
-                type="button"
-                role="tab"
-                aria-selected={view === VIEW_TEAM}
-                className={`team-page__filter-btn ${view === VIEW_TEAM ? 'is-active' : ''}`}
-                onClick={() => setView(VIEW_TEAM)}
-              >
-                Team
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={view === VIEW_YOU}
-                className={`team-page__filter-btn ${view === VIEW_YOU ? 'is-active' : ''}`}
-                onClick={() => setView(VIEW_YOU)}
-              >
-                You
-              </button>
-            </div>
-            <div
-              className="team-page__filter"
-              role="tablist"
-              aria-label="Scope metrics by year or current quarter"
-            >
-              <button
-                type="button"
-                role="tab"
-                aria-selected={scope === SCOPE_YEAR}
-                className={`team-page__filter-btn ${scope === SCOPE_YEAR ? 'is-active' : ''}`}
-                onClick={() => setScope(SCOPE_YEAR)}
-              >
-                For the Year
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={scope === SCOPE_QUARTER}
-                className={`team-page__filter-btn ${scope === SCOPE_QUARTER ? 'is-active' : ''}`}
-                onClick={() => setScope(SCOPE_QUARTER)}
-                title={`Current quarter: ${getCurrentQuarterShortLabel()}`}
-              >
-                Current Quarter
-              </button>
-            </div>
-          </div>
-
-          {/*
-            "Tickets closed by you" — personal Linear roll-up. Only
-            renders in the You view; on Team view the page focuses
-            on the SF roll-up + AE breakdown below. The fragment
-            wraps two sibling sections (tickets tiles + monthly
-            breakdown chart) under the same view gate.
-          */}
-          {view === VIEW_YOU && (
-            <>
-              <section className="team-page__section">
-                <div className="team-page__section-header">
-                  <div className="team-page__section-heading">
-                    <h2 className="team-page__section-title">Tickets closed by you</h2>
-                    <p className="team-page__section-subtitle">
-                      {(() => {
-                        const subject = firstName ? `${firstName} has` : "you've";
-                        const window =
-                          scope === SCOPE_QUARTER
-                            ? `this quarter (${getCurrentQuarterShortLabel()})`
-                            : 'this year';
-                        return `Linear tickets ${subject} completed ${window}.`;
-                      })()}
-                    </p>
-                  </div>
-                </div>
-                {linearClosed?.needsLinearProfile ? (
-                  // SE row exists but we couldn't auto-resolve their Linear
-                  // user ID from email. Surface the same hint the dashboard
-                  // would, but inline so the section still has presence.
-                  <p className="team-page__linear-hint">
-                    We couldn&apos;t match your account to a Linear user yet. Check your Profile so
-                    we can pull in your closed tickets.
-                  </p>
-                ) : linearError || linearClosed?.error === 'linear_unavailable' ? (
-                  // Either the request itself blew up (linearError) or the
-                  // backend returned a soft 200 indicating Linear was
-                  // unreachable. Same UX in both cases — a calm
-                  // "try again later" beats spinning placeholders forever.
-                  <p className="team-page__linear-hint">
-                    Couldn&apos;t load your closed tickets right now. Try refreshing in a minute.
-                  </p>
-                ) : (
-                  <div
-                    className="team-page__totals"
-                    // The You view shows 4 tiles (adds AI Demo). Override
-                    // the default 3-column layout via the parameterized
-                    // `--tile-cols` custom property so we don't need a
-                    // dedicated modifier class for this single use.
-                    style={{ '--tile-cols': 4 }}
-                  >
-                    {/*
-                  Four tiles: Tickets Closed (total) + Estimation +
-                  Creation + AI Demo. Reuses `.metric-summary--detailed`
-                  so the layout is identical to At a glance on the
-                  Team view. Each tile carries a small "avg Xd to
-                  close" caption (pulled from createdAt →
-                  completedAt). The caption is suppressed when a
-                  category has zero closed tickets so we don't render
-                  a misleading "0d".
-                */}
-                    <article className="metric-summary metric-summary--detailed">
-                      <div className="metric-summary__head">
-                        <span className="metric-summary__label">Tickets Closed</span>
-                        <span className="metric-summary__icon" aria-hidden="true">
-                          <LuClipboardCheck />
-                        </span>
-                      </div>
-                      <div className="metric-summary__value">
-                        {closedTicketsScoped
-                          ? closedTicketsScoped.total.toLocaleString('en-US')
-                          : '—'}
-                      </div>
-                      {closedTicketsScoped &&
-                        formatAvgLeadTime(closedTicketsScoped.avgDaysTotal) && (
-                          <div className="metric-summary__foot">
-                            <span className="metric-summary__hint">
-                              {formatAvgLeadTime(closedTicketsScoped.avgDaysTotal)}
-                            </span>
-                          </div>
-                        )}
-                    </article>
-
-                    <article className="metric-summary metric-summary--detailed">
-                      <div className="metric-summary__head">
-                        <span className="metric-summary__label">Estimation</span>
-                        <span className="metric-summary__icon" aria-hidden="true">
-                          <LuFilePen />
-                        </span>
-                      </div>
-                      <div className="metric-summary__value">
-                        {closedTicketsScoped
-                          ? closedTicketsScoped.estimation.toLocaleString('en-US')
-                          : '—'}
-                      </div>
-                      {closedTicketsScoped &&
-                        formatAvgLeadTime(closedTicketsScoped.avgDaysEstimation) && (
-                          <div className="metric-summary__foot">
-                            <span className="metric-summary__hint">
-                              {formatAvgLeadTime(closedTicketsScoped.avgDaysEstimation)}
-                            </span>
-                          </div>
-                        )}
-                    </article>
-
-                    <article className="metric-summary metric-summary--detailed">
-                      <div className="metric-summary__head">
-                        <span className="metric-summary__label">Creation</span>
-                        <span className="metric-summary__icon" aria-hidden="true">
-                          <LuHammer />
-                        </span>
-                      </div>
-                      <div className="metric-summary__value">
-                        {closedTicketsScoped
-                          ? closedTicketsScoped.creation.toLocaleString('en-US')
-                          : '—'}
-                      </div>
-                      {closedTicketsScoped &&
-                        formatAvgLeadTime(closedTicketsScoped.avgDaysCreation) && (
-                          <div className="metric-summary__foot">
-                            <span className="metric-summary__hint">
-                              {formatAvgLeadTime(closedTicketsScoped.avgDaysCreation)}
-                            </span>
-                          </div>
-                        )}
-                    </article>
-
-                    <article className="metric-summary metric-summary--detailed">
-                      <div className="metric-summary__head">
-                        <span className="metric-summary__label">AI Demo</span>
-                        <span className="metric-summary__icon" aria-hidden="true">
-                          <LuSparkles />
-                        </span>
-                      </div>
-                      <div className="metric-summary__value">
-                        {closedTicketsScoped
-                          ? (closedTicketsScoped.aiDemo ?? 0).toLocaleString('en-US')
-                          : '—'}
-                      </div>
-                      {closedTicketsScoped &&
-                        formatAvgLeadTime(closedTicketsScoped.avgDaysAiDemo) && (
-                          <div className="metric-summary__foot">
-                            <span className="metric-summary__hint">
-                              {formatAvgLeadTime(closedTicketsScoped.avgDaysAiDemo)}
-                            </span>
-                          </div>
-                        )}
-                    </article>
-                  </div>
-                )}
-              </section>
-
-              {/*
-            Monthly breakdown — second section in the You view. A
-            quarter-tab strip across the top picks which quarter the
-            chart renders. Bars are monthly counts; the caption under
-            each bar is that month's share of the quarter (the user's
-            requested "closed percentage per ticket").
-          */}
-              {linearClosed?.configured && (
-                <section className="team-page__section">
-                  <div className="team-page__section-header">
-                    <div className="team-page__section-heading">
-                      <h2 className="team-page__section-title">Monthly breakdown</h2>
-                      <p className="team-page__section-subtitle">
-                        Tickets you closed each month of Q{selectedQuarter} {linearClosed.year}.
-                      </p>
-                    </div>
-                    <div
-                      className="team-page__filter team-page__filter--quarters"
-                      role="tablist"
-                      aria-label="Pick a quarter"
-                    >
-                      {[1, 2, 3, 4].map((q) => (
-                        <button
-                          key={q}
-                          type="button"
-                          role="tab"
-                          aria-selected={selectedQuarter === q}
-                          className={`team-page__filter-btn ${
-                            selectedQuarter === q ? 'is-active' : ''
-                          }`}
-                          onClick={() => setSelectedQuarter(q)}
-                        >
-                          Q{q}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  {selectedQuarterBucket ? (
-                    selectedQuarterBucket.total === 0 ? (
-                      <p className="team-page__linear-hint">
-                        No tickets closed in Q{selectedQuarter} {linearClosed.year} yet.
-                      </p>
-                    ) : (
-                      // Build the line chart. We compute the y-axis
-                      // ceiling from the largest single-category count
-                      // (not the month total) because the chart plots
-                      // per-category lines — using the month total would
-                      // leave huge headroom above every line. Floor at
-                      // 1 to dodge a divide-by-zero on empty quarters.
-                      (() => {
-                        const months = selectedQuarterBucket.byMonth || [];
-                        const dataMax = Math.max(
-                          1,
-                          ...months.flatMap((m) => CHART_CATEGORIES.map((c) => m[c.key] || 0)),
-                        );
-                        const yMax = niceChartMax(dataMax);
-                        const yTicks = buildYTicks(yMax);
-
-                        const plotW = CHART_VIEWBOX_W - CHART_PAD.left - CHART_PAD.right;
-                        const plotH = CHART_VIEWBOX_H - CHART_PAD.top - CHART_PAD.bottom;
-                        // X anchors data points to the plot edges (first
-                        // month at left, last at right) — standard line-
-                        // chart layout for sparse series like 3 months.
-                        const xOf = (i) =>
-                          months.length === 1
-                            ? CHART_PAD.left + plotW / 2
-                            : CHART_PAD.left + (i / (months.length - 1)) * plotW;
-                        const yOf = (v) => CHART_PAD.top + plotH - (v / yMax) * plotH;
-
-                        return (
-                          <>
-                            <div
-                              className="team-page__chart"
-                              role="img"
-                              aria-label={`Monthly closed tickets for Q${selectedQuarter} ${linearClosed.year}, with one line per ticket type`}
-                            >
-                              <svg
-                                className="team-page__chart-svg"
-                                viewBox={`0 0 ${CHART_VIEWBOX_W} ${CHART_VIEWBOX_H}`}
-                                preserveAspectRatio="xMidYMid meet"
-                                role="presentation"
-                              >
-                                {/* Y-axis gridlines + count labels.
-                                Drawn first so they sit behind the
-                                lines instead of slicing across them. */}
-                                {yTicks.map((tick) => (
-                                  <g key={`y-${tick}`}>
-                                    <line
-                                      className="team-page__chart-grid"
-                                      x1={CHART_PAD.left}
-                                      y1={yOf(tick)}
-                                      x2={CHART_VIEWBOX_W - CHART_PAD.right}
-                                      y2={yOf(tick)}
-                                    />
-                                    <text
-                                      className="team-page__chart-axis"
-                                      x={CHART_PAD.left - 8}
-                                      y={yOf(tick)}
-                                      textAnchor="end"
-                                      dominantBaseline="middle"
-                                    >
-                                      {tick}
-                                    </text>
-                                  </g>
-                                ))}
-
-                                {/* X-axis month labels, centered below
-                                each data point. */}
-                                {months.map((m, i) => (
-                                  <text
-                                    key={`x-${m.month}`}
-                                    className="team-page__chart-axis team-page__chart-axis--x"
-                                    x={xOf(i)}
-                                    y={CHART_VIEWBOX_H - CHART_PAD.bottom + 22}
-                                    textAnchor="middle"
-                                  >
-                                    {m.label}
-                                  </text>
-                                ))}
-
-                                {/* One polyline per category, with a dot
-                                at each month's data point. The dot
-                                carries a <title> so hovering the
-                                point shows "Creation - May: 4". */}
-                                {CHART_CATEGORIES.map((cat) => {
-                                  const points = months
-                                    .map((m, i) => `${xOf(i)},${yOf(m[cat.key] || 0)}`)
-                                    .join(' ');
-                                  const catTotal = selectedQuarterBucket?.[cat.key] || 0;
-                                  return (
-                                    <g
-                                      key={cat.key}
-                                      className={`team-page__chart-series team-page__chart-series--${cat.key}${
-                                        catTotal === 0 ? ' team-page__chart-series--muted' : ''
-                                      }`}
-                                    >
-                                      <polyline
-                                        className="team-page__chart-line"
-                                        points={points}
-                                        fill="none"
-                                      />
-                                      {months.map((m, i) => (
-                                        <circle
-                                          key={m.month}
-                                          className="team-page__chart-dot"
-                                          cx={xOf(i)}
-                                          cy={yOf(m[cat.key] || 0)}
-                                          r="4"
-                                        >
-                                          <title>{`${cat.label} · ${m.label}: ${m[cat.key] || 0}`}</title>
-                                        </circle>
-                                      ))}
-                                    </g>
-                                  );
-                                })}
-                              </svg>
-                            </div>
-                            {/*
-                          Legend lives just below the chart so the
-                          color → category mapping is always visible
-                          without making the bars themselves carry
-                          inline labels. Categories with zero across
-                          the whole quarter are dimmed so the legend
-                          quietly self-prunes for sparse quarters.
-                        */}
-                            <ul className="team-page__chart-legend" aria-hidden="true">
-                              {CHART_CATEGORIES.map((cat) => {
-                                const catTotal = selectedQuarterBucket?.[cat.key] || 0;
-                                return (
-                                  <li
-                                    key={cat.key}
-                                    className={`team-page__chart-legend-item ${
-                                      catTotal === 0 ? 'team-page__chart-legend-item--muted' : ''
-                                    }`}
-                                  >
-                                    <span
-                                      className={`team-page__chart-legend-dot team-page__chart-legend-dot--${cat.key}`}
-                                    />
-                                    <span>{cat.label}</span>
-                                    <span className="team-page__chart-legend-count">
-                                      {catTotal.toLocaleString('en-US')}
-                                    </span>
-                                  </li>
-                                );
-                              })}
-                            </ul>
-                            {/*
-                          "Other" tickets disclosure. The Other bucket
-                          is a catch-all for closed tickets that don't
-                          match the Estimation / Creation / AI Demo
-                          patterns; this collapsible list exists so
-                          the SE can scan the actual titles, decide if
-                          a ticket should have been classified, and
-                          open it in Linear to fix the title or label.
-                          Native <details> handles the open/close
-                          state without any React plumbing.
-                        */}
-                            {selectedQuarterBucket.otherTickets &&
-                              selectedQuarterBucket.otherTickets.length > 0 && (
-                                <details className="team-page__chart-other">
-                                  <summary className="team-page__chart-other-summary">
-                                    Show {selectedQuarterBucket.otherTickets.length}{' '}
-                                    {selectedQuarterBucket.otherTickets.length === 1
-                                      ? "'Other' ticket"
-                                      : "'Other' tickets"}
-                                  </summary>
-                                  <ul className="team-page__chart-other-list">
-                                    {selectedQuarterBucket.otherTickets.map((t) => {
-                                      const completed = t.completedAt
-                                        ? new Date(t.completedAt)
-                                        : null;
-                                      const completedLabel =
-                                        completed && !Number.isNaN(completed.getTime())
-                                          ? completed.toLocaleDateString('en-US', {
-                                              month: 'short',
-                                              day: 'numeric',
-                                            })
-                                          : null;
-                                      return (
-                                        <li key={t.id} className="team-page__chart-other-item">
-                                          {t.identifier && (
-                                            <span className="team-page__chart-other-id">
-                                              {t.identifier}
-                                            </span>
-                                          )}
-                                          {t.url ? (
-                                            <a
-                                              className="team-page__chart-other-title"
-                                              href={t.url}
-                                              target="_blank"
-                                              rel="noopener noreferrer"
-                                              title={t.title}
-                                            >
-                                              {t.title}
-                                            </a>
-                                          ) : (
-                                            <span
-                                              className="team-page__chart-other-title"
-                                              title={t.title}
-                                            >
-                                              {t.title}
-                                            </span>
-                                          )}
-                                          {completedLabel && (
-                                            <span className="team-page__chart-other-date">
-                                              {completedLabel}
-                                            </span>
-                                          )}
-                                        </li>
-                                      );
-                                    })}
-                                  </ul>
-                                </details>
-                              )}
-                          </>
-                        );
-                      })()
-                    )
-                  ) : (
-                    <p className="team-page__linear-hint">
-                      No data for Q{selectedQuarter} {linearClosed.year} yet.
-                    </p>
-                  )}
-                </section>
-              )}
-            </>
-          )}
-
-          {/*
-            Team view sections. "At a glance" team-wide rollup tiles
-            followed by per-AE breakdown. The page-level controls bar
-            owns the filter pill, so these sections only carry their
-            own title/subtitle.
-          */}
-          {view === VIEW_TEAM && (
-            <>
-              <section className="team-page__section">
-                <div className="team-page__section-header">
-                  <div className="team-page__section-heading">
-                    <h2 className="team-page__section-title">At a glance</h2>
-                    <p className="team-page__section-subtitle">
-                      {team.name} closed-won performance{' '}
-                      {scope === SCOPE_QUARTER
-                        ? `this quarter (${getCurrentQuarterShortLabel()})`
-                        : 'this year'}
-                      .
-                    </p>
-                  </div>
-                </div>
-                <div className="team-page__totals">
-                  {/*
-                Three tiles share the dashboard's `.metric-summary--detailed`
-                styling so the team page's at-a-glance row reads as
-                the same design language as The Den's metric tiles.
-                Values render "—" while the metrics fetch is in
-                flight so the layout doesn't shift on load.
-              */}
-                  <article className="metric-summary metric-summary--detailed">
-                    <div className="metric-summary__head">
-                      <span className="metric-summary__label">Total CARR</span>
-                      <span className="metric-summary__icon" aria-hidden="true">
-                        <LuTrendingUp />
-                      </span>
-                    </div>
-                    <div className="metric-summary__value">
-                      {data ? formatCompactCurrency(teamTotals.totalCarr) : '—'}
-                    </div>
-                  </article>
-
-                  <article className="metric-summary metric-summary--detailed">
-                    <div className="metric-summary__head">
-                      <span className="metric-summary__label">Closed Opps</span>
-                      <span className="metric-summary__icon" aria-hidden="true">
-                        <LuTrophy />
-                      </span>
-                    </div>
-                    <div className="metric-summary__value">
-                      {data ? teamTotals.count.toLocaleString('en-US') : '—'}
-                    </div>
-                  </article>
-
-                  <article className="metric-summary metric-summary--detailed">
-                    <div className="metric-summary__head">
-                      <span className="metric-summary__label">Avg Deal Size</span>
-                      <span className="metric-summary__icon" aria-hidden="true">
-                        <LuChartBar />
-                      </span>
-                    </div>
-                    <div className="metric-summary__value">
-                      {data ? formatCompactCurrency(teamTotals.avgDealSize) : '—'}
-                    </div>
-                  </article>
-                </div>
-              </section>
-
-              {/* CARR broken down by AE — same scope as the section above. */}
-              <section className="team-page__section">
-                <div className="team-page__section-header">
-                  <div className="team-page__section-heading">
-                    <h2 className="team-page__section-title">CARR broken down by AE</h2>
-                    <p className="team-page__section-subtitle">
-                      Closed-won opportunities for {team.name}{' '}
-                      {scope === SCOPE_QUARTER
-                        ? `this quarter (${getCurrentQuarterShortLabel()})`
-                        : 'this year'}
-                      .
-                    </p>
-                  </div>
-                </div>
-                <div
-                  className="dashboard-widgets team-page__roster"
-                  /*
-            Drive the grid's column count from the AE count so every AE
-            panel ends up on the same row. CSS falls back to the wrapped
-            2-column / 1-column layouts below 1024px so the cards don't
-            get squeezed unreadably narrow on smaller screens.
-          */
-                  style={{ '--ae-count': aes.length }}
+      <div className="team-page__body">
+        {!isLead ? (
+          <p className="page-header__sub">The pack overview is available to leads.</p>
+        ) : (
+          <>
+            <div className="team-page__controls">
+              {selectedDetail && (
+                <button
+                  type="button"
+                  className="team-pack__back"
+                  onClick={() => setSelectedSeId(null)}
                 >
-                  {aes.map((ae) => {
-                    const opps = filteredOppsByAE.get(normalizeName(ae.name)) ?? [];
-                    const totalCarr = sumCarr(opps);
-                    return (
-                      <section
-                        key={ae.id}
-                        className="dashboard-panel"
-                        aria-labelledby={`team-ae-carr-${ae.id}`}
-                      >
-                        <div className="dashboard-panel__head dashboard-panel__head--stacked">
-                          <div className="dashboard-panel__head-text">
-                            <h2 className="dashboard-panel__title" id={`team-ae-carr-${ae.id}`}>
-                              {ae.name}
-                            </h2>
-                            <p className="dashboard-panel__subtitle">
-                              {opps.length === 0
-                                ? 'No closed opps yet'
-                                : `${opps.length} closed ${opps.length === 1 ? 'opp' : 'opps'}`}
-                            </p>
-                          </div>
-                          {/*
-                    Total CARR readout. Only rendered once the metrics
-                    payload has loaded so we don't flash a "$0" total
-                    while the fetch is still in flight. Anchors the
-                    coral column of per-row CARR amounts below.
-                  */}
-                          {data && (
-                            <div className="team-ae-total" aria-label={`Total CARR for ${ae.name}`}>
-                              <span className="team-ae-total__label">Total CARR</span>
-                              <span className="team-ae-total__value">
-                                {formatTotalCarr(totalCarr)}
-                              </span>
-                            </div>
-                          )}
-                        </div>
-
-                        {/*
-                  Three render branches, in priority order:
-                    1. We have opps → show the row list.
-                    2. We have data but this AE has none → quiet hint.
-                    3. We're still waiting on data / hit an error → status row.
-                  Splitting them out (instead of always showing the list)
-                  keeps the panel from flashing an empty state on first
-                  paint while the metrics fetch is in flight.
-                */}
-                        {opps.length > 0 ? (
-                          <ul className="team-ae-opp-list">
-                            {opps.map((opp) => (
-                              <li
-                                key={
-                                  opp.opportunityId || `${opp.opportunityName}-${opp.effectiveDate}`
-                                }
-                                className="team-ae-opp-row"
-                              >
-                                <span className="team-ae-opp-name" title={opp.opportunityName}>
-                                  {opp.opportunityName || 'Untitled opportunity'}
-                                </span>
-                                <span className="team-ae-opp-carr">{formatCarr(opp)}</span>
-                              </li>
-                            ))}
-                          </ul>
-                        ) : data ? (
-                          <p className="team-ae-status">
-                            {scope === SCOPE_QUARTER
-                              ? `No closed opps for ${ae.name} this quarter yet.`
-                              : `No closed opps for ${ae.name} yet this year.`}
-                          </p>
-                        ) : loading ? (
-                          <p className="team-ae-status">Loading closed opps…</p>
-                        ) : error ? (
-                          <p className="team-ae-status">Couldn&apos;t load metrics for this AE.</p>
-                        ) : (
-                          <p className="team-ae-status">No closed opps yet.</p>
-                        )}
-                      </section>
-                    );
-                  })}
-                </div>
-              </section>
-
-              {/*
-            Tickets created broken down by AE — per-AE rollup of Linear
-            tickets each AE has submitted, broken into Creation /
-            Estimation / AI Demo. Sits between the CARR breakdown above
-            and the C opps panel below so the page reads top-to-bottom
-            as: revenue earned (CARR) → workload generated (tickets) →
-            visibility-only revenue (C opps). Same scope filter as the
-            other Team-view sections (year vs current quarter).
-
-            Currently hidden behind the `SHOW_TICKETS_BY_AE` flag while
-            the data quality (AE field-name drift, Slack-bot mention
-            attribution, nickname matching) is being shaken out on a
-            follow-up branch. Backend endpoint, classifier, and
-            extraction work all stay live — flip the flag back to
-            `true` to re-render the section.
-          */}
-              {SHOW_TICKETS_BY_AE && (
-                <section className="team-page__section">
-                  <div className="team-page__section-header">
-                    <div className="team-page__section-heading">
-                      <h2 className="team-page__section-title">
-                        Tickets created broken down by AE
-                      </h2>
-                      <p className="team-page__section-subtitle">
-                        Linear tickets each AE on {team.name} has submitted{' '}
-                        {scope === SCOPE_QUARTER
-                          ? `this quarter (${getCurrentQuarterShortLabel()})`
-                          : 'this year'}
-                        .
-                      </p>
-                    </div>
-                  </div>
-                  {ticketsByAEError || ticketsByAE?.error === 'linear_unavailable' ? (
-                    <p className="team-page__linear-hint">
-                      Couldn&apos;t load tickets-by-AE right now. Try refreshing in a minute.
-                    </p>
-                  ) : (
-                    <div
-                      className="dashboard-widgets team-page__roster"
-                      /*
-                  Same column layout as the CARR roster above so the
-                  two AE rosters read as one continuous billboard. AE
-                  count drives the column count via the shared
-                  `--ae-count` custom property; we add 1 when there
-                  are unassigned tickets so the extra "Unassigned"
-                  card at the end of the row gets its own column
-                  rather than pushing one of the AE cards onto a
-                  new line.
-                */
-                      style={{
-                        '--ae-count': aes.length + (unassignedScoped.total > 0 ? 1 : 0),
-                      }}
-                    >
-                      {ticketsByAEScoped.map(({ ae, total, estimation, creation, aiDemo }) => (
-                        <section
-                          key={ae.id}
-                          className="dashboard-panel team-ae-tickets"
-                          aria-labelledby={`team-ae-tickets-${ae.id}`}
-                        >
-                          <div className="dashboard-panel__head dashboard-panel__head--stacked">
-                            <div className="dashboard-panel__head-text">
-                              <h2
-                                className="dashboard-panel__title"
-                                id={`team-ae-tickets-${ae.id}`}
-                              >
-                                {ae.name}
-                              </h2>
-                              <p className="dashboard-panel__subtitle">
-                                {ticketsByAE
-                                  ? total === 0
-                                    ? 'No tickets submitted yet'
-                                    : `${total} ${total === 1 ? 'ticket' : 'tickets'} submitted`
-                                  : 'Loading…'}
-                              </p>
-                            </div>
-                            {/*
-                          Total readout mirrors the CARR section's
-                          `.team-ae-total` treatment so the two
-                          rosters share a head-right anchor element.
-                          Hidden until the fetch resolves so the
-                          number doesn't flicker from "0" → real.
-                        */}
-                            {ticketsByAE && (
-                              <div
-                                className="team-ae-total"
-                                aria-label={`Total tickets submitted by ${ae.name}`}
-                              >
-                                <span className="team-ae-total__label">Total</span>
-                                <span className="team-ae-total__value">
-                                  {total.toLocaleString('en-US')}
-                                </span>
-                              </div>
-                            )}
-                          </div>
-
-                          {ticketsByAE ? (
-                            // Three category chips (Creation / Estimation /
-                            // AI Demo) reuse the chart legend's colored
-                            // dots so the same color → category mapping
-                            // stays consistent with the You view chart.
-                            // "Other" is intentionally omitted from the
-                            // breakdown — it's the catch-all for tickets
-                            // we couldn't classify, and AEs don't pick
-                            // their ticket's "Type of Ask" so showing it
-                            // would be more confusing than useful.
-                            <ul
-                              className="team-ae-tickets-breakdown"
-                              aria-label={`Ticket breakdown for ${ae.name}`}
-                            >
-                              <li className="team-ae-tickets-breakdown__item">
-                                <span className="team-ae-tickets-breakdown__dot team-ae-tickets-breakdown__dot--creation" />
-                                <span className="team-ae-tickets-breakdown__label">Creation</span>
-                                <span className="team-ae-tickets-breakdown__value">
-                                  {creation.toLocaleString('en-US')}
-                                </span>
-                              </li>
-                              <li className="team-ae-tickets-breakdown__item">
-                                <span className="team-ae-tickets-breakdown__dot team-ae-tickets-breakdown__dot--estimation" />
-                                <span className="team-ae-tickets-breakdown__label">Estimation</span>
-                                <span className="team-ae-tickets-breakdown__value">
-                                  {estimation.toLocaleString('en-US')}
-                                </span>
-                              </li>
-                              <li className="team-ae-tickets-breakdown__item">
-                                <span className="team-ae-tickets-breakdown__dot team-ae-tickets-breakdown__dot--aiDemo" />
-                                <span className="team-ae-tickets-breakdown__label">AI Demo</span>
-                                <span className="team-ae-tickets-breakdown__value">
-                                  {aiDemo.toLocaleString('en-US')}
-                                </span>
-                              </li>
-                            </ul>
-                          ) : (
-                            <p className="team-ae-status">Loading ticket breakdown…</p>
-                          )}
-                        </section>
-                      ))}
-
-                      {/*
-                  Unassigned card. Tickets where the AE / Contract Owner
-                  field couldn't be extracted from the description show
-                  up here so the SE can see exactly which tickets need
-                  to be fixed at the source. Only renders when there's
-                  at least one unattributed ticket in scope — the card
-                  would otherwise be a constant "0" reminder that
-                  nothing's broken. Visually flagged with the
-                  `--unassigned` modifier (warm warning border + label
-                  treatment) so it reads as "go fix this" rather than a
-                  fourth peer AE.
-                */}
-                      {ticketsByAE && unassignedScoped.total > 0 && (
-                        <section
-                          className="dashboard-panel team-ae-tickets team-ae-tickets--unassigned"
-                          aria-labelledby="team-ae-tickets-unassigned"
-                        >
-                          <div className="dashboard-panel__head dashboard-panel__head--stacked">
-                            <div className="dashboard-panel__head-text">
-                              <h2
-                                className="dashboard-panel__title"
-                                id="team-ae-tickets-unassigned"
-                              >
-                                Unassigned
-                              </h2>
-                              <p className="dashboard-panel__subtitle">
-                                {unassignedScoped.total === 1
-                                  ? '1 ticket missing AE'
-                                  : `${unassignedScoped.total} tickets missing AE`}
-                              </p>
-                            </div>
-                            <div className="team-ae-total" aria-label="Total tickets missing AE">
-                              <span className="team-ae-total__label">Total</span>
-                              <span className="team-ae-total__value team-ae-total__value--unassigned">
-                                {unassignedScoped.total.toLocaleString('en-US')}
-                              </span>
-                            </div>
-                          </div>
-
-                          <ul
-                            className="team-ae-tickets-breakdown"
-                            aria-label="Unassigned ticket breakdown"
-                          >
-                            <li className="team-ae-tickets-breakdown__item">
-                              <span className="team-ae-tickets-breakdown__dot team-ae-tickets-breakdown__dot--creation" />
-                              <span className="team-ae-tickets-breakdown__label">Creation</span>
-                              <span className="team-ae-tickets-breakdown__value">
-                                {unassignedScoped.creation.toLocaleString('en-US')}
-                              </span>
-                            </li>
-                            <li className="team-ae-tickets-breakdown__item">
-                              <span className="team-ae-tickets-breakdown__dot team-ae-tickets-breakdown__dot--estimation" />
-                              <span className="team-ae-tickets-breakdown__label">Estimation</span>
-                              <span className="team-ae-tickets-breakdown__value">
-                                {unassignedScoped.estimation.toLocaleString('en-US')}
-                              </span>
-                            </li>
-                            <li className="team-ae-tickets-breakdown__item">
-                              <span className="team-ae-tickets-breakdown__dot team-ae-tickets-breakdown__dot--aiDemo" />
-                              <span className="team-ae-tickets-breakdown__label">AI Demo</span>
-                              <span className="team-ae-tickets-breakdown__value">
-                                {unassignedScoped.aiDemo.toLocaleString('en-US')}
-                              </span>
-                            </li>
-                          </ul>
-
-                          {/*
-                      Native <details> drives the "show me which tickets"
-                      disclosure — same pattern as the You-view chart's
-                      "Show N 'Other' tickets" disclosure so the two
-                      surfaces feel consistent. Each row links to the
-                      Linear ticket so the SE can one-click into it,
-                      add the AE field, and the count drops on the
-                      next refresh.
-                    */}
-                          {unassignedScoped.tickets.length > 0 && (
-                            <details className="team-ae-tickets-disclosure">
-                              <summary className="team-ae-tickets-disclosure__summary">
-                                Show {unassignedScoped.tickets.length}{' '}
-                                {unassignedScoped.tickets.length === 1
-                                  ? 'ticket to fix'
-                                  : 'tickets to fix'}
-                              </summary>
-                              <ul className="team-ae-tickets-disclosure__list">
-                                {unassignedScoped.tickets.map((t) => (
-                                  <li key={t.id} className="team-ae-tickets-disclosure__item">
-                                    {t.identifier && (
-                                      <span className="team-ae-tickets-disclosure__id">
-                                        {t.identifier}
-                                      </span>
-                                    )}
-                                    {t.url ? (
-                                      <a
-                                        className="team-ae-tickets-disclosure__title"
-                                        href={t.url}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        title={t.title}
-                                      >
-                                        {t.title}
-                                      </a>
-                                    ) : (
-                                      <span
-                                        className="team-ae-tickets-disclosure__title"
-                                        title={t.title}
-                                      >
-                                        {t.title}
-                                      </span>
-                                    )}
-                                  </li>
-                                ))}
-                              </ul>
-                            </details>
-                          )}
-                        </section>
-                      )}
-                    </div>
-                  )}
-                </section>
+                  <LuArrowLeft aria-hidden="true" />
+                  Back to the pack
+                </button>
               )}
+              <div className="team-page__scope">
+                <select
+                  className="team-page__year"
+                  value={selectedYear}
+                  onChange={(e) => setSelectedYear(Number(e.target.value))}
+                  aria-label="Year"
+                >
+                  {AVAILABLE_YEARS.map((y) => (
+                    <option key={y} value={y}>
+                      {y}
+                    </option>
+                  ))}
+                </select>
+                <div
+                  className="team-page__filter"
+                  role="tablist"
+                  aria-label="Scope metrics by full year or quarter"
+                >
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={quarter === 0}
+                    className={`team-page__filter-btn ${quarter === 0 ? 'is-active' : ''}`}
+                    onClick={() => setQuarter(0)}
+                  >
+                    Full Year
+                  </button>
+                  {[1, 2, 3, 4].map((q) => (
+                    <button
+                      key={q}
+                      type="button"
+                      role="tab"
+                      aria-selected={quarter === q}
+                      className={`team-page__filter-btn ${quarter === q ? 'is-active' : ''}`}
+                      onClick={() => setQuarter(q)}
+                    >
+                      Q{q}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
 
-              {/*
-            Closed-won C opps. Account-Score-C deals don't count toward
-            the CARR goal (which is why they're absent from the tiles
-            and per-AE cards above), but they're still real revenue —
-            this panel surfaces every C opp on the team in a flat
-            Opp / AE / CARR layout so a single skim shows what was
-            closed and who closed it without the reader having to
-            unfold per-AE groups.
-
-            Year-gated to 2026+. Earlier years' reports don't have an
-            Account Score column at all (so `accountScore` is empty,
-            `isCScore` is always false, and `cTeamTotals.count` is
-            always 0). Hiding the section entirely on those years
-            keeps 2025 reading exactly as it did before this feature
-            shipped instead of always rendering an empty hint.
-          */}
-              {currentYear >= 2026 && (
-                <section className="team-page__section">
-                  <div className="team-page__section-header">
-                    <div className="team-page__section-heading">
-                      <h2 className="team-page__section-title">Closed-won C opps</h2>
+            <section className="team-page__section">
+              <div className="team-page__section-header">
+                <div className="team-page__section-heading">
+                  {selectedDetail ? (
+                    <>
+                      <h2 className="team-page__section-title">{selectedDetail.name}</h2>
                       <p className="team-page__section-subtitle">
-                        Account Score C deals don&apos;t count toward the CARR goal, but are tracked
-                        here for visibility{' '}
-                        {scope === SCOPE_QUARTER
-                          ? `this quarter (${getCurrentQuarterShortLabel()})`
-                          : 'this year'}
-                        .
+                        Open workload and tickets completed in {periodLabel}.
                       </p>
-                    </div>
-                  </div>
-                  {/*
-                Single panel that holds the flat row list. We render
-                the panel even when there are zero rows so the empty
-                / loading / error branches share the same surface as
-                the populated state — keeps the layout from jumping
-                around as data arrives.
-              */}
-                  <section className="dashboard-panel" aria-labelledby="team-c-opps-title">
-                    <div className="dashboard-panel__head">
-                      <div className="dashboard-panel__head-text">
-                        <h3 className="dashboard-panel__title" id="team-c-opps-title">
-                          C-scored opportunities
-                        </h3>
-                        <p className="dashboard-panel__subtitle">
-                          {data
-                            ? cTeamTotals.count === 0
-                              ? 'No C-scored deals in scope'
-                              : `${cTeamTotals.count} ${
-                                  cTeamTotals.count === 1 ? 'opp' : 'opps'
-                                } across the team`
-                            : 'Loading…'}
-                        </p>
-                      </div>
-                      {data && cTeamTotals.count > 0 && (
-                        <div
-                          className="team-ae-total"
-                          aria-label="Total C-scored CARR for the team"
-                        >
-                          <span className="team-ae-total__label">Total CARR</span>
-                          <span className="team-ae-total__value">
-                            {formatTotalCarr(cTeamTotals.totalCarr)}
+                    </>
+                  ) : (
+                    <>
+                      <h2 className="team-page__section-title">The Pack</h2>
+                      <p className="team-page__section-subtitle">
+                        Creation, scoping, and completed tickets per SE in {periodLabel}. Click an
+                        SE for their workload and full breakdown.
+                      </p>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              {packError ? (
+                <p className="team-page__linear-hint">
+                  Couldn&apos;t load the pack overview right now. Try refreshing in a minute.
+                </p>
+              ) : !packData ? (
+                <p className="team-page__linear-hint">Loading the pack…</p>
+              ) : selectedDetail ? (
+                <>
+                  <div className="team-page__totals" style={{ '--tile-cols': 5 }}>
+                    {[
+                      {
+                        label: 'Workload',
+                        value: selectedDetail.open,
+                        hint: 'open right now',
+                        Icon: LuInbox,
+                      },
+                      { label: 'Completed', value: selectedDetail.completed, Icon: LuCircleCheck },
+                      { label: 'Creation', value: selectedDetail.creation, Icon: LuFilePlus },
+                      { label: 'Scoping', value: selectedDetail.scoping, Icon: LuRuler },
+                      { label: 'AI Demo', value: selectedDetail.aiDemo, Icon: LuSparkles },
+                    ].map((tile) => (
+                      <article key={tile.label} className="team-pack-detail__tile">
+                        <div className="team-pack-detail__head">
+                          <span className="team-pack-detail__label">{tile.label}</span>
+                          <span className="team-pack-detail__icon" aria-hidden="true">
+                            <tile.Icon />
                           </span>
                         </div>
-                      )}
-                    </div>
+                        <span className="team-pack-detail__value">
+                          {tile.value.toLocaleString('en-US')}
+                        </span>
+                        {tile.hint && <span className="team-pack-detail__hint">{tile.hint}</span>}
+                      </article>
+                    ))}
+                  </div>
 
-                    {/*
-                  Render branches mirror the AE roster's pattern above:
-                  populated list → empty hint → loading → error. The
-                  populated branch is a flat list — one row per opp,
-                  most recent close on top — with the AE responsible
-                  for the deal sitting in the middle column so the
-                  reader can attribute each row at a glance.
-                */}
-                    {data && cOppsForTeam.length > 0 ? (
-                      <ul className="team-c-opps-list">
-                        {/*
-                      Header row uses the same grid layout as the data
-                      rows below so the columns line up exactly. Marked
-                      aria-hidden because the per-cell aria-labels and
-                      the panel's overall section labelling already
-                      carry the semantics for assistive tech.
-                    */}
-                        <li className="team-c-opps-row team-c-opps-row--head" aria-hidden="true">
-                          <span className="team-c-opps-row__opp">Opportunity</span>
-                          <span className="team-c-opps-row__ae">AE</span>
-                          <span className="team-c-opps-row__carr">CARR</span>
-                        </li>
-                        {cOppsForTeam.map(({ opp, aeName }) => (
-                          <li
-                            key={opp.opportunityId || `${opp.opportunityName}-${opp.effectiveDate}`}
-                            className="team-c-opps-row"
+                  <section className="team-cal">
+                    <h3 className="team-cal__heading">Today&apos;s calendar</h3>
+                    <SeCalendar payload={seCalendar} error={seCalendarError} />
+                  </section>
+
+                  <TicketLists
+                    error={seTicketsError}
+                    loaded={Boolean(seTickets)}
+                    open={seTickets?.open || []}
+                    closed={visibleClosedTickets}
+                    periodLabel={periodLabel}
+                  />
+                </>
+              ) : packRows.length === 0 ? (
+                <p className="team-page__linear-hint">No Sales Engineers in the pack yet.</p>
+              ) : (
+                <>
+                  <div className="team-page__totals team-pack-totals" style={{ '--tile-cols': 4 }}>
+                    {[
+                      {
+                        label: 'Workload',
+                        value: packTotals.open,
+                        hint: 'open across the pack',
+                        Icon: LuInbox,
+                      },
+                      { label: 'Creation', value: packTotals.creation, Icon: LuFilePlus },
+                      { label: 'Scoping', value: packTotals.scoping, Icon: LuRuler },
+                      { label: 'Completed', value: packTotals.completed, Icon: LuCircleCheck },
+                    ].map((tile) => (
+                      <article key={tile.label} className="team-pack-detail__tile">
+                        <div className="team-pack-detail__head">
+                          <span className="team-pack-detail__label">{tile.label}</span>
+                          <span className="team-pack-detail__icon" aria-hidden="true">
+                            <tile.Icon />
+                          </span>
+                        </div>
+                        <span className="team-pack-detail__value">
+                          {tile.value.toLocaleString('en-US')}
+                        </span>
+                        {tile.hint && <span className="team-pack-detail__hint">{tile.hint}</span>}
+                      </article>
+                    ))}
+                  </div>
+
+                  <section
+                    className="dashboard-panel team-pack-chart"
+                    aria-label="Pack overview by SE"
+                  >
+                    <svg
+                      className="team-pack-chart__svg"
+                      viewBox={`0 0 ${CHART.w} ${CHART.h}`}
+                      role="img"
+                      aria-label="Creation, scoping, and completed tickets per Sales Engineer"
+                    >
+                      {chartLayout.yTicks.map((t) => {
+                        const y = chartLayout.baseY - (t / chartLayout.yMax) * chartLayout.plotH;
+                        return (
+                          <g key={t}>
+                            <line
+                              className="team-pack-chart__grid"
+                              x1={CHART.padLeft}
+                              y1={y}
+                              x2={CHART.w - CHART.padRight}
+                              y2={y}
+                            />
+                            <text
+                              className="team-pack-chart__ytick"
+                              x={CHART.padLeft - 8}
+                              y={y}
+                              textAnchor="end"
+                              dominantBaseline="middle"
+                            >
+                              {t}
+                            </text>
+                          </g>
+                        );
+                      })}
+
+                      {chartLayout.groups.map((g) => (
+                        <g
+                          key={g.seId}
+                          className="team-pack-chart__group"
+                          role="button"
+                          tabIndex={0}
+                          aria-label={`View ${g.name}'s details`}
+                          onClick={() => selectSe(g.seId)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              selectSe(g.seId);
+                            }
+                          }}
+                        >
+                          {/* Transparent hit area spanning the full plot height so
+                            the whole column is clickable, not just the bars. */}
+                          <rect
+                            className="team-pack-chart__hit"
+                            x={g.cx - chartLayout.plotW / chartLayout.groups.length / 2}
+                            y={CHART.padTop}
+                            width={chartLayout.plotW / chartLayout.groups.length}
+                            height={chartLayout.plotH}
+                          />
+                          {g.bars.map((b) => (
+                            <g key={b.key} className="team-pack-chart__bar-cell">
+                              <rect
+                                className={`team-pack-chart__bar team-pack-chart__bar--${b.key}`}
+                                x={b.x}
+                                y={b.y}
+                                width={b.w}
+                                height={b.h}
+                                rx="2"
+                              />
+                              <text
+                                className="team-pack-chart__bar-value"
+                                x={b.x + b.w / 2}
+                                y={b.y - 6}
+                                textAnchor="middle"
+                              >
+                                {b.val}
+                              </text>
+                            </g>
+                          ))}
+                          <text
+                            className="team-pack-chart__xlabel"
+                            x={g.cx}
+                            y={CHART.h - CHART.padBottom + 20}
+                            textAnchor="middle"
                           >
-                            <span className="team-c-opps-row__opp" title={opp.opportunityName}>
-                              {opp.opportunityName || 'Untitled opportunity'}
+                            {g.label}
+                          </text>
+                        </g>
+                      ))}
+                    </svg>
+
+                    <div className="team-pack-chart__legend">
+                      {CHART_SERIES.map((s) => (
+                        <span
+                          key={s.key}
+                          className={`team-pack-chart__legend-item team-pack-chart__legend-item--${s.key}`}
+                        >
+                          <span className="team-pack-chart__legend-swatch" aria-hidden="true" />
+                          {s.label}
+                        </span>
+                      ))}
+                    </div>
+                  </section>
+
+                  {packCarr && packCarr.configured && carrBreakdown.total > 0 && (
+                    <section className="dashboard-panel team-carr" aria-label="Closed CARR by SE">
+                      <div className="team-carr__header">
+                        <h3 className="team-carr__title">Closed CARR by SE</h3>
+                        <span className="team-carr__total">
+                          {formatCompactUSD(carrBreakdown.total)}
+                        </span>
+                      </div>
+                      <ul className="team-carr__list">
+                        {carrBreakdown.rows.map((row) => (
+                          <li key={row.seId} className="team-carr__row">
+                            <span className="team-carr__name" title={row.name}>
+                              {row.name}
                             </span>
-                            <span className="team-c-opps-row__ae" title={aeName}>
-                              {aeName}
+                            <span className="team-carr__track">
+                              <span
+                                className="team-carr__bar"
+                                style={{
+                                  width: `${
+                                    carrBreakdown.max > 0 ? (row.carr / carrBreakdown.max) * 100 : 0
+                                  }%`,
+                                }}
+                              />
                             </span>
-                            <span className="team-c-opps-row__carr">{formatCarr(opp)}</span>
+                            <span className="team-carr__amount">{formatCompactUSD(row.carr)}</span>
                           </li>
                         ))}
                       </ul>
-                    ) : data ? (
-                      <p className="team-ae-status">
-                        No C-scored closed-won opps for this team{' '}
-                        {scope === SCOPE_QUARTER ? 'this quarter yet.' : 'yet this year.'}
+                      <p className="team-carr__note">
+                        Closed in {periodLabel}, attributed by each closed-won deal&apos;s AE and
+                        the team they belong to.
                       </p>
-                    ) : loading ? (
-                      <p className="team-ae-status">Loading C-scored opps…</p>
-                    ) : error ? (
-                      <p className="team-ae-status">Couldn&apos;t load metrics for C opps.</p>
-                    ) : (
-                      <p className="team-ae-status">No C-scored opps yet.</p>
-                    )}
-                  </section>
-                </section>
+                    </section>
+                  )}
+                </>
               )}
-            </>
-          )}
-        </div>
-      )}
+            </section>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/projects/team/team.less
+++ b/frontend/src/projects/team/team.less
@@ -176,7 +176,45 @@
   margin: 0 0 1.5rem;
 }
 
-// Pill-style segmented control for the year / current-quarter scope.
+// Scope cluster: a year dropdown sitting beside the full-year / quarter
+// pills. Kept together on the right of the controls row; wraps as a unit.
+.team-page__scope {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+// Year dropdown — mirrors the dark-theme select used in the ticket filter
+// bar so the two controls read as the same family.
+.team-page__year {
+  appearance: none;
+  height: 2.5rem;
+  padding: 0 2rem 0 0.9rem;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 9999px;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 0.7rem;
+
+  &:focus-visible {
+    outline: 2px solid var(--coral);
+    outline-offset: 2px;
+  }
+
+  option {
+    color: initial;
+  }
+}
+
+// Pill-style segmented control for the full-year / quarter scope.
 // Lives inside the section header on the right and toggles which
 // opps the AE roster renders. Visually inspired by the dashboard's
 // other quiet pill elements (.dashboard-source-pill, etc.) — dark
@@ -966,4 +1004,944 @@
   color: rgba(255, 255, 255, 0.5);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+}
+
+// ---------------------------------------------------------------------------
+// Lead "Pack" view — one sortable table of every SE in the pack. Lives
+// inside a `.dashboard-panel` so it shares the same card surface as the
+// rest of the team page; the table itself borrows the dim-uppercase
+// header treatment from `.team-c-opps-row--head` and the coral CARR
+// column from `.team-c-opps-row__carr` for visual continuity.
+// ---------------------------------------------------------------------------
+// Inset the table from the card edges so the names aren't jammed
+// against the left border and the "Completed" column isn't kissing the
+// right one. The first/last cells stay flush to the table itself; this
+// padding provides the gutter to the panel.
+.team-pack {
+  padding: 1.25rem 1.75rem;
+}
+
+// Horizontal scroll container so the five columns never squeeze into
+// unreadable widths on narrow viewports — the table keeps its min-width
+// and the panel scrolls instead.
+.team-pack__scroll {
+  width: 100%;
+  overflow-x: auto;
+}
+
+// Fixed layout so the explicit column widths below are honored exactly:
+// the name column (no width) soaks up the remaining space while each of
+// the three numeric columns is a predictable 9rem, keeping the headers
+// directly above their numbers with even, readable spacing.
+.team-pack__table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  min-width: 680px;
+}
+
+.team-pack__th {
+  padding: 0 1rem 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  vertical-align: bottom;
+  white-space: nowrap;
+
+  &:first-child {
+    padding-left: 0;
+  }
+
+  &:last-child {
+    padding-right: 0;
+  }
+
+  &--left {
+    text-align: left;
+  }
+
+  &--right {
+    text-align: right;
+    width: 9rem;
+  }
+}
+
+// The header label doubles as the sort control. Styled as a flush text
+// button (no chrome) so it reads as a column header until hovered.
+.team-pack__sort {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.55);
+  transition: color 0.15s ease;
+
+  .team-pack__th--right & {
+    width: 100%;
+    text-align: right;
+  }
+
+  &:hover {
+    color: var(--white);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--coral);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  .team-pack__th.is-active & {
+    color: var(--coral);
+  }
+}
+
+.team-pack__row {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  // Data rows are drill-downs into a per-SE detail panel — make that
+  // affordance obvious with a pointer + hover wash, and keep keyboard
+  // users in the loop with a focus ring.
+  &--clickable {
+    cursor: pointer;
+    transition: background 0.12s ease;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.04);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--coral);
+      outline-offset: -2px;
+      border-radius: 4px;
+    }
+  }
+
+  // Footer total row: a heavier top rule and brighter text so the
+  // pack-wide bottom line reads as a summary rather than another SE.
+  &--total {
+    border-top: 1px solid rgba(255, 255, 255, 0.14);
+
+    .team-pack__td {
+      font-weight: 700;
+      color: var(--white);
+      padding-top: 0.7rem;
+    }
+
+    .team-pack__td--carr {
+      color: var(--coral);
+    }
+  }
+}
+
+// "Back to the pack" control. Lives in the controls row (opposite the
+// scope pills) as a compact pill button so it reads as a clear, tappable
+// breadcrumb instead of floating awkwardly above the heading.
+.team-pack__back {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.95rem;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 9999px;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  &:hover {
+    color: var(--coral);
+    border-color: var(--coral);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--coral);
+    outline-offset: 2px;
+  }
+}
+
+// Per-SE detail tiles (reuses the `.team-page__totals` grid for the
+// column layout). Self-contained so the panel renders correctly even
+// though the page no longer loads the shared `.metric-summary` widget.
+.team-pack-detail__tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1.1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+}
+
+.team-pack-detail__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.team-pack-detail__label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+// Icon chip in the tile head, echoing the homepage `.metric-summary__icon`
+// treatment (coral glyph on a soft tinted square) so the detail view reads
+// as part of the same family as the other pages' metric cards.
+.team-pack-detail__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 8px;
+  color: var(--coral);
+  background: rgba(255, 107, 74, 0.12);
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
+.team-pack-detail__value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--white);
+  font-variant-numeric: tabular-nums;
+}
+
+.team-pack-detail__hint {
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+// --- Drill-down ticket lists ------------------------------------------------
+// The SE's actual Linear tickets, shown below the headline tiles. Two
+// stacked groups (open workload + completed-in-scope), each a list of
+// linkable rows with a category chip and a date.
+.team-tickets {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  margin-top: 1.75rem;
+}
+
+// Today's-calendar block in the SE drill-down. Sits between the headline
+// tiles and the ticket lists. Reuses the global `dashboard-calendar`
+// styles for the event rows; this only owns the heading + spacing.
+.team-cal {
+  margin-top: 1.75rem;
+}
+
+.team-cal__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0 0 0.85rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--white);
+}
+
+// Column filter bar above the lists: a title search plus category /
+// project / status dropdowns. Wraps on narrow widths; the search grows
+// to fill leftover space.
+.team-tickets__filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.team-tickets__search,
+.team-tickets__select {
+  appearance: none;
+  height: 2.25rem;
+  padding: 0 0.75rem;
+  font: inherit;
+  font-size: 0.85rem;
+  color: var(--white);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.22);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--coral);
+    background: rgba(255, 255, 255, 0.06);
+  }
+}
+
+.team-tickets__search {
+  flex: 1 1 12rem;
+  min-width: 9rem;
+
+  &::placeholder {
+    color: rgba(255, 255, 255, 0.4);
+  }
+}
+
+.team-tickets__select {
+  flex: 0 0 auto;
+  max-width: 14rem;
+  padding-right: 1.75rem;
+  cursor: pointer;
+  // Custom caret so the native select matches the dark theme.
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.6rem center;
+  background-size: 0.7rem;
+
+  option {
+    color: initial;
+  }
+}
+
+.team-tickets__clear {
+  appearance: none;
+  flex: 0 0 auto;
+  height: 2.25rem;
+  padding: 0 0.85rem;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--coral);
+  background: transparent;
+  border: 1px solid rgba(255, 107, 74, 0.4);
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover {
+    background: rgba(255, 107, 74, 0.1);
+    border-color: var(--coral);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--coral);
+    outline-offset: 2px;
+  }
+}
+
+.team-tickets__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0 0 0.85rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--white);
+}
+
+// Collapsible-group header. A full-width text button so the whole row is
+// a click target; the chevron rotates to point down when expanded.
+.team-tickets__toggle {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  margin: 0 0 0.85rem;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--white);
+  text-align: left;
+
+  &:hover .team-tickets__heading-text {
+    color: var(--coral);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--coral);
+    outline-offset: 3px;
+    border-radius: 4px;
+  }
+}
+
+.team-tickets__heading-text {
+  transition: color 0.12s ease;
+}
+
+.team-tickets__toggle-icon {
+  flex: 0 0 auto;
+  width: 1.05rem;
+  height: 1.05rem;
+  color: rgba(255, 255, 255, 0.55);
+  transform: rotate(-90deg);
+  transition: transform 0.15s ease;
+
+  &.is-open {
+    transform: rotate(0deg);
+  }
+}
+
+.team-tickets__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.45rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 9999px;
+}
+
+.team-tickets__empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.team-tickets__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.team-tickets__row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.7rem 0.95rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+}
+
+// Category chip. Fixed width so the titles line up in a clean column
+// regardless of label length.
+.team-tickets__chip {
+  flex: 0 0 auto;
+  width: 5.5rem;
+  text-align: center;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-radius: 6px;
+  color: var(--white);
+
+  &--creation {
+    background: rgba(255, 107, 74, 0.18);
+    color: #ff8c6b;
+  }
+
+  &--scoping {
+    background: rgba(41, 121, 255, 0.18);
+    color: #6ea8ff;
+  }
+
+  &--aidemo {
+    background: rgba(76, 175, 80, 0.18);
+    color: #7bd17f;
+  }
+
+  &--other {
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.7);
+  }
+}
+
+.team-tickets__main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.team-tickets__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--white);
+  text-decoration: none;
+  min-width: 0;
+}
+
+.team-tickets__title-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.team-tickets__title-icon {
+  flex: 0 0 auto;
+  width: 0.85rem;
+  height: 0.85rem;
+  opacity: 0;
+  color: var(--coral);
+  transition: opacity 0.12s ease;
+}
+
+a.team-tickets__title:hover {
+  color: var(--coral);
+
+  .team-tickets__title-icon {
+    opacity: 1;
+  }
+}
+
+a.team-tickets__title:focus-visible {
+  outline: 2px solid var(--coral);
+  outline-offset: 2px;
+  border-radius: 3px;
+
+  .team-tickets__title-icon {
+    opacity: 1;
+  }
+}
+
+// Right-aligned metadata group (status · due date · completed date).
+// Pushed to the far edge so each row spans the full width of the bar
+// instead of bunching everything on the left.
+.team-tickets__side {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.85rem;
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding-left: 0.5rem;
+}
+
+.team-tickets__project {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.45);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 22rem;
+}
+
+// Workflow-state pill (e.g. "In Progress", "Done"). Color-coded by tone
+// (see `statusTone` in index.jsx) so a lead can scan states at a glance;
+// unknown states fall back to the neutral `--default` treatment.
+.team-tickets__status {
+  flex: 0 0 auto;
+  padding: 0.12rem 0.55rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  border-radius: 9999px;
+  white-space: nowrap;
+
+  // Each tone: tinted fill, matching border, and a brightened text color.
+  &--default {
+    color: rgba(255, 255, 255, 0.75);
+    background: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  &--todo {
+    color: #9fb6d6;
+    background: rgba(159, 182, 214, 0.15);
+    border: 1px solid rgba(159, 182, 214, 0.3);
+  }
+
+  &--backlog {
+    color: rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+  }
+
+  &--progress {
+    color: #6ea8ff;
+    background: rgba(41, 121, 255, 0.16);
+    border: 1px solid rgba(41, 121, 255, 0.4);
+  }
+
+  &--review {
+    color: #c79bff;
+    background: rgba(167, 122, 255, 0.16);
+    border: 1px solid rgba(167, 122, 255, 0.4);
+  }
+
+  &--blocked {
+    color: #ff8c6b;
+    background: rgba(255, 107, 74, 0.16);
+    border: 1px solid rgba(255, 107, 74, 0.42);
+  }
+
+  &--done {
+    color: #7bd17f;
+    background: rgba(76, 175, 80, 0.16);
+    border: 1px solid rgba(76, 175, 80, 0.4);
+  }
+
+  &--canceled {
+    color: rgba(255, 255, 255, 0.45);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    text-decoration: line-through;
+  }
+}
+
+.team-tickets__due {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.55);
+  white-space: nowrap;
+
+  // Urgency tones for near-term / overdue deadlines on open tickets.
+  &--default {
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.55);
+  }
+
+  &--soon {
+    color: #f4c25b;
+  }
+
+  &--today {
+    color: #ff8c6b;
+  }
+
+  &--overdue {
+    color: #ff6b4a;
+    font-weight: 700;
+  }
+}
+
+.team-tickets__due-icon {
+  width: 0.8rem;
+  height: 0.8rem;
+  opacity: 0.8;
+}
+
+.team-tickets__date {
+  flex: 0 0 auto;
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.team-pack__td {
+  padding: 0.6rem 1rem;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.85);
+
+  &:first-child {
+    padding-left: 0;
+  }
+
+  &:last-child {
+    padding-right: 0;
+  }
+
+  &--name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 600;
+    color: var(--white);
+  }
+
+  &--num {
+    width: 9rem;
+    text-align: right;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &--carr {
+    font-weight: 700;
+    color: var(--coral);
+  }
+}
+
+// --- Pack grouped bar chart -------------------------------------------------
+// Replaces the pack table on the team page: one group of three bars
+// (Creation / Scoping / Completed) per SE. The SVG scales to the panel
+// width via its viewBox; each group is a clickable button that drills
+// into the SE detail panel.
+// Pack-wide summary cards above the chart.
+.team-pack-totals {
+  margin-bottom: 1.25rem;
+}
+
+// --- Closed CARR by SE breakdown -------------------------------------------
+// Horizontal ranked bars under the chart: SE name, a proportional CARR
+// bar, and the formatted amount. Shares the dark panel surface.
+.team-carr {
+  margin-top: 1.25rem;
+  padding: 1.5rem 1.75rem;
+  height: auto;
+  overflow: visible;
+}
+
+.team-carr__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.1rem;
+}
+
+.team-carr__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--white);
+}
+
+.team-carr__total {
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: var(--success-green-alt);
+  font-variant-numeric: tabular-nums;
+}
+
+.team-carr__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.team-carr__row {
+  display: grid;
+  grid-template-columns: 9rem 1fr 5rem;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.team-carr__name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.team-carr__track {
+  position: relative;
+  height: 0.85rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+.team-carr__bar {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: 9999px;
+  background: linear-gradient(90deg, rgba(76, 175, 80, 0.7), var(--success-green-alt));
+  transition: width 0.3s ease;
+}
+
+.team-carr__amount {
+  text-align: right;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--white);
+  font-variant-numeric: tabular-nums;
+}
+
+.team-carr__note {
+  margin: 1.1rem 0 0;
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+@media (max-width: 600px) {
+  .team-carr__row {
+    grid-template-columns: 7rem 1fr 4.5rem;
+    gap: 0.6rem;
+  }
+}
+
+.team-pack-chart {
+  padding: 1.5rem 1.75rem 1.25rem;
+  // The shared `.dashboard-panel` locks itself to a fixed 24rem height
+  // with `overflow-y: auto`, which clips the chart and forces a scroll.
+  // The chart already scales to a sensible height via its viewBox, so
+  // let the panel grow to fit and drop the inner scrollbar.
+  height: auto;
+  overflow: visible;
+}
+
+.team-pack-chart__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.team-pack-chart__grid {
+  stroke: rgba(255, 255, 255, 0.08);
+  stroke-width: 1;
+}
+
+.team-pack-chart__ytick {
+  fill: rgba(255, 255, 255, 0.45);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.team-pack-chart__xlabel {
+  fill: rgba(255, 255, 255, 0.7);
+  font-size: 12px;
+  font-weight: 600;
+  transition: fill 0.12s ease;
+}
+
+.team-pack-chart__hit {
+  fill: transparent;
+}
+
+.team-pack-chart__group {
+  cursor: pointer;
+  outline: none;
+
+  &:hover {
+    .team-pack-chart__bar {
+      opacity: 0.82;
+    }
+
+    .team-pack-chart__xlabel {
+      fill: var(--coral);
+    }
+
+    .team-pack-chart__hit {
+      fill: rgba(255, 255, 255, 0.04);
+    }
+  }
+
+  &:focus-visible {
+    .team-pack-chart__xlabel {
+      fill: var(--coral);
+      text-decoration: underline;
+    }
+
+    .team-pack-chart__hit {
+      fill: rgba(255, 255, 255, 0.06);
+    }
+  }
+}
+
+// Per-bar value label, revealed only while that bar is hovered. Sits
+// just above the bar's cap. `pointer-events: none` so the text never
+// steals the hover from the bar (which would make it flicker).
+.team-pack-chart__bar-value {
+  fill: var(--white);
+  font-size: 12px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+
+.team-pack-chart__bar-cell:hover .team-pack-chart__bar-value {
+  opacity: 1;
+}
+
+.team-pack-chart__bar {
+  transition: opacity 0.12s ease;
+
+  &--creation {
+    fill: var(--coral);
+  }
+
+  &--scoping {
+    fill: var(--electric-blue);
+  }
+
+  &--completed {
+    fill: var(--success-green-alt);
+  }
+}
+
+.team-pack-chart__legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.team-pack-chart__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+
+  &--creation .team-pack-chart__legend-swatch {
+    background: var(--coral);
+  }
+
+  &--scoping .team-pack-chart__legend-swatch {
+    background: var(--electric-blue);
+  }
+
+  &--completed .team-pack-chart__legend-swatch {
+    background: var(--success-green-alt);
+  }
+}
+
+.team-pack-chart__legend-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -354,6 +354,47 @@ export async function fetchDashboardLinearTicketsByAE(year) {
   return apiRequest(`/dashboard/linear/tickets-by-ae${query}`);
 }
 
+/**
+ * Team page (lead Pack view): per-SE closed-ticket roll-up for every
+ * active Sales Engineer, plus each SE's assigned AE roster names so the
+ * frontend can pair them with the Salesforce metrics to derive closed
+ * CARR. Admin / SE-lead only on the backend; throws on 403 for other
+ * callers so the UI can hide the Pack toggle. Defaults to the current
+ * calendar year on the backend when `year` is omitted.
+ * @param {number} [year]
+ */
+export async function fetchPackOverview(year) {
+  const query = Number.isInteger(year) ? `?year=${year}` : '';
+  return apiRequest(`/dashboard/pack-overview${query}`);
+}
+
+/**
+ * Per-SE Closed CARR roll-up for the pack (attributed via handoff pages).
+ * Powers the team-page "Closed CARR by SE" breakdown. Lead/admin only.
+ */
+export async function fetchPackCarr(year) {
+  const query = Number.isInteger(year) ? `?year=${year}` : '';
+  return apiRequest(`/dashboard/pack-carr${query}`);
+}
+
+/**
+ * Actual Linear tickets for one SE in the pack (open workload + closed
+ * this year). Powers the team-page drill-down. Lead/admin only.
+ */
+export async function fetchPackSeTickets(seId, year) {
+  const query = Number.isInteger(year) ? `?year=${year}` : '';
+  return apiRequest(`/dashboard/pack-overview/${encodeURIComponent(seId)}/tickets${query}`);
+}
+
+/**
+ * Today's Google Calendar for one SE in the pack. Powers the team-page
+ * drill-down calendar. `configured: false` means the SE hasn't connected
+ * their Google account. Lead/admin only.
+ */
+export async function fetchPackSeCalendar(seId) {
+  return apiRequest(`/dashboard/pack-overview/${encodeURIComponent(seId)}/calendar`);
+}
+
 /** Google Calendar OAuth: returns { authorizationUrl }. */
 export async function startGoogleCalendarOAuth() {
   return apiRequest('/integrations/google/start', {


### PR DESCRIPTION
## Summary
Adds a lead/admin-only **Pack** overview to the Team page so a lead can see how the whole pack is doing at a glance and drill into any individual SE.

- **Pack chart** — grouped bar chart of creation / scoping / completed Linear tickets per SE, with pack-wide total cards and a **year + quarter** scope selector (Full Year / Q1–Q4). The viewing lead is excluded from the chart.
- **Per-SE drill-down** — click an SE to see headline tiles (workload, completed, creation, scoping, AI demo), their **today's Google Calendar**, and their actual Linear tickets with column filters (title search / category / project / status), color-coded status pills, and relative due dates ("today", "in N days", "overdue"). Completed list is collapsible.
- **Closed CARR by SE** — CARR pulled from Salesforce and attributed via each closed-won deal's AE → team → SE, scoped to the selected year/quarter and excluding C-accounts.

### Backend
- New lead-gated dashboard routes: `pack-overview`, `pack-carr`, `pack-overview/:seId/tickets`, and `pack-overview/:seId/calendar`. All honor a `?year=` query param.
- `packCarrService` for per-SE CARR aggregation and a reusable `metricsForYear` Salesforce helper (snapshot-first, live fallback).
- `getCalendarForSE` reads only the SE's own connected Google calendar (no shared service-account fallback); unconnected SEs surface a hint.

## Test plan
- [ ] As a lead/admin, open the Team page and confirm the Pack chart renders and total cards match.
- [ ] Switch year + each quarter and confirm chart, CARR, and drill-down ticket counts all rescope.
- [ ] Drill into an SE: verify tiles, calendar (connected vs. not-connected SE), and ticket lists/filters.
- [ ] Confirm a non-lead SE does not get the pack endpoints (403) and sees the lead-only note.
- [ ] Verify CARR totals reconcile with the Salesforce dashboard headline (C-accounts excluded).

Made with [Cursor](https://cursor.com)