### PR TITLE
feat(calculator): opportunity lookup with split added-opps view

### DIFF
--- a/frontend/src/projects/salesforce/calculator/SalesforceCalculator.css
+++ b/frontend/src/projects/salesforce/calculator/SalesforceCalculator.css
@@ -394,6 +394,7 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.75rem;
   margin: 0 0 1.25rem 0;
 }
@@ -445,6 +446,201 @@
 }
 
 /* =========================
+ * Opportunity lookup search
+ * ========================= */
+
+.salesforce-calculator .calculator-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 16rem;
+  max-width: 26rem;
+  margin-left: auto;
+}
+
+.salesforce-calculator .calculator-search-icon {
+  position: absolute;
+  left: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  color: rgba(255, 255, 255, 0.45);
+  pointer-events: none;
+}
+
+.salesforce-calculator .calculator-search-icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.salesforce-calculator .calculator-search-input {
+  width: 100%;
+  padding: 0.55rem 2.25rem 0.55rem 2.35rem;
+  border-radius: 0.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--white);
+  font-size: 0.875rem;
+  font-family: inherit;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.salesforce-calculator .calculator-search-input::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.salesforce-calculator .calculator-search-input:focus {
+  outline: none;
+  border-color: var(--coral);
+  box-shadow: 0 0 0 2px rgba(255, 107, 74, 0.25);
+}
+
+.salesforce-calculator .calculator-search-clear {
+  position: absolute;
+  right: 0.55rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  border: none;
+  border-radius: 0.35rem;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.salesforce-calculator .calculator-search-clear:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--white);
+}
+
+.salesforce-calculator .calculator-search-dropdown {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  right: 0;
+  z-index: 10;
+  max-height: 18rem;
+  overflow-y: auto;
+  background: var(--midnight-navy);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.65rem;
+  box-shadow: 0 16px 32px -12px rgba(0, 0, 0, 0.75);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+}
+
+.salesforce-calculator .calculator-search-status {
+  padding: 0.85rem 1rem;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.6);
+  font-style: italic;
+}
+
+.salesforce-calculator .calculator-search-status--error {
+  color: var(--coral);
+  font-style: normal;
+}
+
+.salesforce-calculator .calculator-search-result {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  width: 100%;
+  padding: 0.65rem 1rem;
+  border: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: transparent;
+  color: var(--white);
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background-color 0.15s ease;
+}
+
+.salesforce-calculator .calculator-search-result:last-child {
+  border-bottom: none;
+}
+
+.salesforce-calculator .calculator-search-result:hover:not(:disabled) {
+  background: rgba(255, 107, 74, 0.1);
+}
+
+.salesforce-calculator .calculator-search-result:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.salesforce-calculator .calculator-search-result-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.salesforce-calculator .calculator-search-result-added {
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(45, 212, 191, 0.15);
+  color: #2dd4bf;
+}
+
+.salesforce-calculator .calculator-search-result-meta {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+/* =========================
+ * Manually added table rows
+ * ========================= */
+
+.salesforce-calculator .calculator-opp-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  max-width: 100%;
+}
+
+.salesforce-calculator .calculator-manual-remove {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.3rem;
+  height: 1.3rem;
+  border: none;
+  border-radius: 0.35rem;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.45);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.salesforce-calculator .calculator-manual-remove:hover {
+  background: rgba(255, 107, 74, 0.16);
+  color: var(--coral);
+}
+
+.salesforce-calculator .calculator-manual-remove svg {
+  width: 0.85rem;
+  height: 0.85rem;
+}
+
+/* =========================
  * Separators + tables
  * ========================= */
 
@@ -464,6 +660,50 @@
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.03) inset,
     0 12px 24px -18px rgba(0, 0, 0, 0.6);
+}
+
+/* Coral-accented variant for the manually added opps table so the split
+   between lookup additions and the report is unmistakable. */
+.salesforce-calculator .table-container--added {
+  border-color: rgba(255, 107, 74, 0.35);
+  background-image:
+    radial-gradient(
+      120% 100% at 0% 0%,
+      rgba(255, 107, 74, 0.1) 0%,
+      rgba(255, 107, 74, 0.02) 40%,
+      transparent 70%
+    ),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0));
+}
+
+.salesforce-calculator .table-container--added .table-title {
+  color: var(--coral);
+}
+
+/* Title sits outside the scroll region so rows never slide past it. */
+.salesforce-calculator .table-title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  text-align: left;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--white);
+  margin: 0 0 0.85rem 0;
+  letter-spacing: -0.01em;
+}
+
+.salesforce-calculator .table-title-hint {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.02em;
+}
+
+/* The scroll region starts exactly at the thead, so the sticky header
+   pins flush to the top with no padding/caption gap for rows to show
+   through while scrolling. */
+.salesforce-calculator .table-scroll {
   max-height: 24rem;
   overflow-y: auto;
   overflow-x: auto;
@@ -471,20 +711,20 @@
   scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
 }
 
-.salesforce-calculator .table-container::-webkit-scrollbar {
+.salesforce-calculator .table-scroll::-webkit-scrollbar {
   width: 8px;
 }
 
-.salesforce-calculator .table-container::-webkit-scrollbar-track {
+.salesforce-calculator .table-scroll::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.salesforce-calculator .table-container::-webkit-scrollbar-thumb {
+.salesforce-calculator .table-scroll::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.2);
   border-radius: 4px;
 }
 
-.salesforce-calculator .table-container::-webkit-scrollbar-thumb:hover {
+.salesforce-calculator .table-scroll::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.3);
 }
 
@@ -495,17 +735,6 @@
   background: transparent;
   table-layout: fixed;
   box-sizing: border-box;
-  caption-side: top;
-}
-
-.salesforce-calculator caption {
-  text-align: left;
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--white);
-  margin: 0 0 0.85rem 0;
-  padding: 0;
-  letter-spacing: -0.01em;
 }
 
 .salesforce-calculator thead {

--- a/frontend/src/projects/salesforce/calculator/index.jsx
+++ b/frontend/src/projects/salesforce/calculator/index.jsx
@@ -1,11 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import { LuTrendingUp, LuCirclePlus, LuTarget, LuActivity, LuTrophy } from 'react-icons/lu';
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  LuTrendingUp,
+  LuCirclePlus,
+  LuTarget,
+  LuActivity,
+  LuTrophy,
+  LuSearch,
+  LuX,
+} from 'react-icons/lu';
 import {
   fetchSalesforceReport,
   getSalesforceConfig,
   fetchSalesforceSnapshotMetrics,
   fetchSalesforceSnapshotCalculator,
+  searchOpportunities,
 } from '../../../services/api';
+import { lookupPrimaryRevenue, formatCurrency } from '../lookup/opportunityHelpers';
 import './SalesforceCalculator.css';
 
 function getCurrentQuarter() {
@@ -19,6 +29,10 @@ function getCurrentQuarter() {
   else quarter = 4;
   return `Q${quarter} CY${year}`;
 }
+
+// Salesforce IDs come in 15-char (reports) and 18-char (REST API) forms;
+// the first 15 chars are identical, so compare on those.
+const normalizeSfId = (id) => (id || '').slice(0, 15);
 
 const COMPENSATION_ROLE_META = {
   'sales engineer 1': { accentClass: 'compensation-card--se1' },
@@ -36,6 +50,14 @@ const SalesforceCalculator = () => {
   const [selectedOpps, setSelectedOpps] = useState([]);
   const [sortColumn, setSortColumn] = useState(null);
   const [sortDirection, setSortDirection] = useState('asc');
+  const [manualOpps, setManualOpps] = useState([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [searchResults, setSearchResults] = useState([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchDebounce = useRef(null);
+  const searchContainerRef = useRef(null);
 
   const currentQuarter = getCurrentQuarter();
   const currentYear = new Date().getFullYear();
@@ -112,6 +134,89 @@ const SalesforceCalculator = () => {
     };
   }, [config, currentYear]);
 
+  useEffect(() => {
+    if (searchDebounce.current) clearTimeout(searchDebounce.current);
+    const trimmed = searchTerm.trim();
+    if (trimmed.length < 2) {
+      setSearchResults([]);
+      setSearchError(null);
+      setSearching(false);
+      return;
+    }
+    searchDebounce.current = setTimeout(async () => {
+      setSearching(true);
+      setSearchError(null);
+      try {
+        const res = await searchOpportunities(trimmed);
+        setSearchResults(res.success ? res.data || [] : []);
+        setSearchOpen(true);
+      } catch (err) {
+        setSearchError(err.message || 'Search failed');
+        setSearchResults([]);
+        setSearchOpen(true);
+      } finally {
+        setSearching(false);
+      }
+    }, 350);
+    return () => clearTimeout(searchDebounce.current);
+  }, [searchTerm]);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (searchContainerRef.current && !searchContainerRef.current.contains(e.target)) {
+        setSearchOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const addManualOpp = (sfOpp) => {
+    const normalizedId = normalizeSfId(sfOpp.id);
+    const reportMatch = (data?.data || []).find(
+      (opp) => normalizeSfId(opp.opportunityId) === normalizedId,
+    );
+
+    if (reportMatch) {
+      // Already in the report table — just select that row.
+      setSelectedOpps((prev) =>
+        prev.includes(reportMatch.opportunityId) ? prev : [...prev, reportMatch.opportunityId],
+      );
+    } else {
+      const revenue = lookupPrimaryRevenue(sfOpp);
+      const manualOpp = {
+        opportunityId: sfOpp.id,
+        opportunityName: sfOpp.name || '(unnamed)',
+        stage: sfOpp.stage || '',
+        quarter: '',
+        type: sfOpp.type || '',
+        aeName: sfOpp.ownerName || '',
+        probability: typeof sfOpp.probability === 'number' ? sfOpp.probability : null,
+        probabilityFormatted: sfOpp.probability != null ? `${sfOpp.probability}%` : '—',
+        carrAmount: Number(revenue) || 0,
+        amount: null,
+        isManual: true,
+      };
+      setManualOpps((prev) =>
+        prev.some((opp) => normalizeSfId(opp.opportunityId) === normalizedId)
+          ? prev
+          : [...prev, manualOpp],
+      );
+      setSelectedOpps((prev) =>
+        prev.includes(manualOpp.opportunityId) ? prev : [...prev, manualOpp.opportunityId],
+      );
+    }
+
+    setSearchTerm('');
+    setSearchResults([]);
+    setSearchOpen(false);
+  };
+
+  const removeManualOpp = (opportunityId) => {
+    setManualOpps((prev) => prev.filter((opp) => opp.opportunityId !== opportunityId));
+    setSelectedOpps((prev) => prev.filter((id) => id !== opportunityId));
+  };
+
   const toggleSelection = (opportunityId) => {
     setSelectedOpps((prev) => {
       if (prev.includes(opportunityId)) {
@@ -139,10 +244,24 @@ const SalesforceCalculator = () => {
   const currentQuarterCARR = selectedQuarterData?.totalCARR || 0;
   const currentQuarterCARRFormatted = `$${currentQuarterCARR.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
-  const allOpportunities = data?.data || [];
-  const totalOpportunities = data?.totalOpportunities || 0;
+  const reportOpportunities = data?.data || [];
+  const reportOppIds = new Set(reportOpportunities.map((opp) => normalizeSfId(opp.opportunityId)));
+  const visibleManualOpps = manualOpps.filter(
+    (opp) => !reportOppIds.has(normalizeSfId(opp.opportunityId)),
+  );
+  const allOpportunities = [...visibleManualOpps, ...reportOpportunities];
+  const existingOppIds = new Set(allOpportunities.map((opp) => normalizeSfId(opp.opportunityId)));
 
-  const sortedOpportunities = [...allOpportunities].sort((a, b) => {
+  // The Added table mirrors everything counted in the projection: lookup
+  // additions plus any report rows the user has checked.
+  const addedOpps = [
+    ...visibleManualOpps,
+    ...reportOpportunities.filter((opp) => selectedOpps.includes(opp.opportunityId)),
+  ];
+
+  // Sorting only applies to the high-probability table; added opps live in
+  // their own table in the order they were added.
+  const sortedOpportunities = [...reportOpportunities].sort((a, b) => {
     if (!sortColumn) return 0;
     let aValue, bValue;
     switch (sortColumn) {
@@ -172,7 +291,7 @@ const SalesforceCalculator = () => {
 
   const opportunities = sortedOpportunities;
 
-  const addedTotalCARR = opportunities
+  const addedTotalCARR = allOpportunities
     .filter((opp) => selectedOpps.includes(opp.opportunityId))
     .reduce((sum, opp) => sum + (opp.carrAmount || 0), 0);
   const addedTotalCARRFormatted = `$${addedTotalCARR.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -192,7 +311,59 @@ const SalesforceCalculator = () => {
   };
 
   const clearSelection = () => setSelectedOpps([]);
-  const selectAll = () => setSelectedOpps(opportunities.map((opp) => opp.opportunityId));
+  const selectAll = () => setSelectedOpps(allOpportunities.map((opp) => opp.opportunityId));
+
+  const renderOppRow = (opportunity, { removable = false } = {}) => {
+    const isSelected = selectedOpps.includes(opportunity.opportunityId);
+    const showRemove = opportunity.isManual || removable;
+    const handleRemove = (e) => {
+      e.stopPropagation();
+      if (opportunity.isManual) {
+        removeManualOpp(opportunity.opportunityId);
+      } else {
+        setSelectedOpps((prev) => prev.filter((id) => id !== opportunity.opportunityId));
+      }
+    };
+    return (
+      <tr
+        key={opportunity.opportunityId}
+        className={isSelected ? 'selected' : ''}
+        onClick={() => toggleSelection(opportunity.opportunityId)}
+      >
+        <td>
+          <input
+            type="checkbox"
+            className="calculator-checkbox"
+            checked={isSelected}
+            onChange={() => toggleSelection(opportunity.opportunityId)}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </td>
+        <td>
+          <span className="calculator-opp-name">
+            {opportunity.opportunityName}
+            {showRemove && (
+              <button
+                type="button"
+                className="calculator-manual-remove"
+                aria-label={`Remove ${opportunity.opportunityName}`}
+                onClick={handleRemove}
+              >
+                <LuX />
+              </button>
+            )}
+          </span>
+        </td>
+        <td>{opportunity.stage}</td>
+        <td>{opportunity.aeName}</td>
+        <td>{opportunity.probabilityFormatted || `${opportunity.probability}%`}</td>
+        <td>
+          {opportunity.amount ||
+            `$${(opportunity.carrAmount || 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+        </td>
+      </tr>
+    );
+  };
 
   const getProgressClass = (percentage) => {
     if (percentage < 30) return 'progress-bar-low';
@@ -357,7 +528,9 @@ const SalesforceCalculator = () => {
         <button
           className="btn-calculator btn-calculator--primary"
           onClick={selectAll}
-          disabled={opportunities.length === 0 || selectedOpps.length === opportunities.length}
+          disabled={
+            allOpportunities.length === 0 || selectedOpps.length === allOpportunities.length
+          }
         >
           Select All
         </button>
@@ -368,80 +541,159 @@ const SalesforceCalculator = () => {
         >
           Clear Selection ({selectedOpps.length})
         </button>
+
+        <div className="calculator-search" ref={searchContainerRef}>
+          <span className="calculator-search-icon" aria-hidden="true">
+            <LuSearch />
+          </span>
+          <input
+            type="text"
+            className="calculator-search-input"
+            placeholder="Look up an opportunity to add…"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            onFocus={() => {
+              if (searchTerm.trim().length >= 2) setSearchOpen(true);
+            }}
+          />
+          {searchTerm && (
+            <button
+              type="button"
+              className="calculator-search-clear"
+              aria-label="Clear search"
+              onClick={() => {
+                setSearchTerm('');
+                setSearchResults([]);
+                setSearchOpen(false);
+              }}
+            >
+              <LuX />
+            </button>
+          )}
+          {(searching || searchOpen) && searchTerm.trim().length >= 2 && (
+            <div className="calculator-search-dropdown">
+              {searching && <div className="calculator-search-status">Searching Salesforce…</div>}
+              {!searching && searchError && (
+                <div className="calculator-search-status calculator-search-status--error">
+                  {searchError}
+                </div>
+              )}
+              {!searching && !searchError && searchResults.length === 0 && (
+                <div className="calculator-search-status">No matching opportunities found</div>
+              )}
+              {!searching &&
+                !searchError &&
+                searchResults.map((result) => {
+                  const alreadyAdded = existingOppIds.has(normalizeSfId(result.id));
+                  const revenue = lookupPrimaryRevenue(result);
+                  return (
+                    <button
+                      type="button"
+                      key={result.id}
+                      className="calculator-search-result"
+                      onClick={() => addManualOpp(result)}
+                    >
+                      <span className="calculator-search-result-name">
+                        {result.name || '(unnamed)'}
+                        {alreadyAdded && (
+                          <span className="calculator-search-result-added">
+                            In table — click to select
+                          </span>
+                        )}
+                      </span>
+                      <span className="calculator-search-result-meta">
+                        {result.accountName || 'Unknown account'} · {result.stage || 'No stage'} ·{' '}
+                        {formatCurrency(revenue)}
+                      </span>
+                    </button>
+                  );
+                })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="table-container table-container--added">
+        <div className="table-title">
+          Added Opportunities ({addedOpps.length})
+          <span className="table-title-hint">Selected from the report or added via lookup</span>
+        </div>
+        <div className="table-scroll">
+          <table aria-label={`Added Opportunities (${addedOpps.length})`}>
+            <thead>
+              <tr>
+                <th>Select</th>
+                <th>Opportunity Name</th>
+                <th>Stage</th>
+                <th>AE Name</th>
+                <th>Probability</th>
+                <th>CARR</th>
+              </tr>
+            </thead>
+            <tbody>
+              {addedOpps.length === 0 ? (
+                <tr>
+                  <td colSpan="6" className="empty-row">
+                    No opportunities added yet — select from the table below or use the lookup above
+                  </td>
+                </tr>
+              ) : (
+                addedOpps.map((opp) => renderOppRow(opp, { removable: true }))
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
 
       <div className="table-container">
-        <table>
-          <caption>High Probability Opportunities ({totalOpportunities})</caption>
-          <thead>
-            <tr>
-              <th>Select</th>
-              <th className="sortable" onClick={() => handleSort('opportunityName')}>
-                Opportunity Name
-                {sortColumn === 'opportunityName' && (
-                  <span className="sort-indicator">{sortDirection === 'asc' ? ' ▲' : ' ▼'}</span>
-                )}
-              </th>
-              <th>Stage</th>
-              <th className="sortable" onClick={() => handleSort('aeName')}>
-                AE Name
-                {sortColumn === 'aeName' && (
-                  <span className="sort-indicator">{sortDirection === 'asc' ? ' ▲' : ' ▼'}</span>
-                )}
-              </th>
-              <th className="sortable" onClick={() => handleSort('probability')}>
-                Probability
-                {sortColumn === 'probability' && (
-                  <span className="sort-indicator">{sortDirection === 'asc' ? ' ▲' : ' ▼'}</span>
-                )}
-              </th>
-              <th className="sortable" onClick={() => handleSort('carrAmount')}>
-                CARR
-                {sortColumn === 'carrAmount' && (
-                  <span className="sort-indicator">{sortDirection === 'asc' ? ' ▲' : ' ▼'}</span>
-                )}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {opportunities.length === 0 ? (
+        <div className="table-title">
+          High Probability Opportunities ({reportOpportunities.length})
+        </div>
+        <div className="table-scroll">
+          <table aria-label={`High Probability Opportunities (${reportOpportunities.length})`}>
+            <thead>
               <tr>
-                <td colSpan="6" className="empty-row">
-                  No opportunities found
-                </td>
+                <th>Select</th>
+                <th className="sortable" onClick={() => handleSort('opportunityName')}>
+                  Opportunity Name
+                  {sortColumn === 'opportunityName' && (
+                    <span className="sort-indicator">{sortDirection === 'asc' ? ' ▲' : ' ▼'}</span>
+                  )}
+                </th>
+                <th>Stage</th>
+                <th className="sortable" onClick={() => handleSort('aeName')}>
+                  AE Name
+                  {sortColumn === 'aeName' && (
+                    <span className="sort-indicator">{sortDirection === 'asc' ? ' ▲' : ' ▼'}</span>
+                  )}
+                </th>
+                <th className="sortable" onClick={() => handleSort('probability')}>
+                  Probability
+                  {sortColumn === 'probability' && (
+                    <span className="sort-indicator">{sortDirection === 'asc' ? ' ▲' : ' ▼'}</span>
+                  )}
+                </th>
+                <th className="sortable" onClick={() => handleSort('carrAmount')}>
+                  CARR
+                  {sortColumn === 'carrAmount' && (
+                    <span className="sort-indicator">{sortDirection === 'asc' ? ' ▲' : ' ▼'}</span>
+                  )}
+                </th>
               </tr>
-            ) : (
-              opportunities.map((opportunity) => {
-                const isSelected = selectedOpps.includes(opportunity.opportunityId);
-                return (
-                  <tr
-                    key={opportunity.opportunityId}
-                    className={isSelected ? 'selected' : ''}
-                    onClick={() => toggleSelection(opportunity.opportunityId)}
-                  >
-                    <td>
-                      <input
-                        type="checkbox"
-                        className="calculator-checkbox"
-                        checked={isSelected}
-                        onChange={() => toggleSelection(opportunity.opportunityId)}
-                        onClick={(e) => e.stopPropagation()}
-                      />
-                    </td>
-                    <td>{opportunity.opportunityName}</td>
-                    <td>{opportunity.stage}</td>
-                    <td>{opportunity.aeName}</td>
-                    <td>{opportunity.probabilityFormatted || `${opportunity.probability}%`}</td>
-                    <td>
-                      {opportunity.amount ||
-                        `$${(opportunity.carrAmount || 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {opportunities.length === 0 ? (
+                <tr>
+                  <td colSpan="6" className="empty-row">
+                    No opportunities found
+                  </td>
+                </tr>
+              ) : (
+                opportunities.map((opp) => renderOppRow(opp))
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add a debounced Salesforce opportunity lookup to the Bounty Calculator so any opp can be added to the quarterly projection, even if it's not in the high-probability report
- New split view: a coral-accented "Added Opportunities" table mirrors lookup additions plus any report rows the user checks, each with a remove button; the High Probability table keeps its sorting
- Normalize 15/18-char Salesforce IDs so dedupe between report rows and search results works in both directions; clicking a result already in the report selects that row instead of doing nothing
- Fix sticky table header bleed-through while scrolling by moving the caption and padding out of the scroll region

## Test plan
- [ ] Search for an opp not in the report, add it, verify it appears in Added Opportunities auto-selected and CARR/projection/compensation update
- [ ] Search for an opp already in the report, click it, verify the report row gets checked
- [ ] Check/uncheck report rows and verify they mirror in/out of the Added Opportunities table
- [ ] Remove added opps via the x button and verify totals update
- [ ] Scroll the report table and verify rows no longer show above the sticky header

Made with [Cursor](https://cursor.com)