### PR TITLE
fix(opps): link done Linear tickets in handoff sheets + update retired Claude model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ OPENAI_MODEL=gpt-4o-mini
 
 # Claude Configuration
 ANTHROPIC_API_KEY="op://Shared - Sale Engineer/AI Keys/Anthropic"
+ANTHROPIC_MODEL=claude-sonnet-4-6
 
 # QA Wolf
 QAW_BEARER_TOKEN="op://Shared - Sale Engineer/QAW Bearer Token/TOKEN"

--- a/backend/src/services/anthropicService.js
+++ b/backend/src/services/anthropicService.js
@@ -8,7 +8,10 @@ dotenv.config({ path: resolve(__dirname, '../../.env') });
 dotenv.config({ path: resolve(__dirname, '../../../.env') });
 dotenv.config();
 
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+// claude-sonnet-4-20250514 was retired by Anthropic on 2026-06-15; the
+// recommended replacement is claude-sonnet-4-6. Overridable via env so the
+// model can be bumped without a code change.
+const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6';
 
 // Lazily initialized so the key is read at call time, not at module load time
 let _anthropic = null;

--- a/backend/src/services/linearDashboardService.js
+++ b/backend/src/services/linearDashboardService.js
@@ -1706,13 +1706,16 @@ export async function mergeManualLinearLinks(baseBuckets, identifiers) {
 // Dedicated picker query -- mirrors TEAM_ISSUES_QUERY but adds the extra
 // fields mapOppTicket() expects (assignee + createdAt) so the picker can
 // show "assigned to X, created Y" hints without a second fetch.
+//
+// Note: we only exclude canceled tickets here -- completed/done tickets
+// must remain selectable so handoff sheets can be linked to finished work.
 const PICKER_ISSUES_QUERY = `
   query MyPickerIssues($teamId: ID!, $assigneeId: ID!, $after: String) {
     issues(
       filter: {
         team: { id: { eq: $teamId } }
         assignee: { id: { eq: $assigneeId } }
-        state: { type: { nin: ["completed", "canceled"] } }
+        state: { type: { nin: ["canceled"] } }
       }
       first: 100
       after: $after
@@ -1737,13 +1740,16 @@ const PICKER_ISSUES_QUERY = `
 `;
 
 /**
- * Return the logged-in SE's currently-open Linear tickets in the same shape
- * `findLinearTicketsForOpp` uses, so the manual-link picker can render
- * them with familiar fields (identifier, title, state, project, etc.).
+ * Return the logged-in SE's Linear tickets (including completed/done ones)
+ * in the same shape `findLinearTicketsForOpp` uses, so the manual-link
+ * picker can render them with familiar fields (identifier, title, state,
+ * project, etc.).
  *
- * Intentionally broader than the dashboard's "Active Hunts" view -- we
- * don't filter out internal projects or non-opportunity tickets, because
- * the SE explicitly knows which ticket they're trying to link.
+ * Intentionally broad: we keep completed tickets selectable (handoff sheets
+ * are frequently created from already-done work) and only drop canceled
+ * ones, which are never worth linking. We also don't filter out internal
+ * projects or non-opportunity tickets, because the SE explicitly knows
+ * which ticket they're trying to link.
  */
 export async function listMyOpenLinearTickets(userId) {
   const empty = { configured: false, tickets: [] };

--- a/frontend/src/projects/opps/components/LinkLinearTicketModal.jsx
+++ b/frontend/src/projects/opps/components/LinkLinearTicketModal.jsx
@@ -4,8 +4,9 @@ import { listMyLinearTickets, linkLinearTicket } from '../../../services/api';
 /**
  * Modal picker for manually linking a Linear ticket to an Opp.
  *
- * Shows the caller's currently-open Linear tickets so the SE can click
- * the one they want to link rather than copy-pasting an identifier. The
+ * Shows the caller's Linear tickets (including completed/done ones) so the
+ * SE can click the one they want to link rather than copy-pasting an
+ * identifier. The
  * already-linked rawIds (auto-discovered + previously manual) are passed
  * in via `excludeRawIds` so we hide tickets that would otherwise be
  * idempotent no-ops.
@@ -99,7 +100,7 @@ function LinkLinearTicketModal({ oppId, excludeRawIds = [], onClose, onLinked })
       <div className="opp-modal opp-link-modal" role="dialog" aria-modal="true">
         <h3 className="opp-modal__title">Link a Linear ticket</h3>
         <p className="opp-modal__sub">
-          Pick from your open Linear tickets, or paste a different ticket&apos;s identifier (e.g.{' '}
+          Pick from your Linear tickets, or paste a different ticket&apos;s identifier (e.g.{' '}
           <code>AXO-959</code>) if the AE assigned it to someone else.
         </p>
 
@@ -135,7 +136,7 @@ function LinkLinearTicketModal({ oppId, excludeRawIds = [], onClose, onLinked })
             {filtered.length === 0 ? (
               <p className="opp-section__placeholder">
                 {state.tickets.length === 0
-                  ? 'No open tickets assigned to you right now.'
+                  ? 'No tickets assigned to you right now.'
                   : 'No tickets match your search.'}
               </p>
             ) : (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -492,9 +492,9 @@ export async function deleteOpp(id) {
 }
 
 /**
- * List the caller's currently-open Linear tickets for the manual-link
- * picker on the Opp detail page. Returns `{ configured, tickets }` --
- * the picker hides itself when Linear isn't wired up.
+ * List the caller's Linear tickets (including completed/done ones) for the
+ * manual-link picker on the Opp detail page. Returns `{ configured, tickets }`
+ * -- the picker hides itself when Linear isn't wired up.
  */
 export async function listMyLinearTickets() {
   return apiRequest('/opps/linear/my-tickets');


### PR DESCRIPTION
## Summary
- Fixes [AXO-1068](https://linear.app/qawolf/issue/AXO-1068/done-linear-tickets-cant-be-linked-in-handoff-sheets): completed/done Linear tickets were excluded from the "Link a Linear ticket" picker, so handoff sheets couldn't be linked to finished work. The picker query (`listMyOpenLinearTickets`) filtered out `completed` tickets; it now only excludes `canceled` ones.
- Updates `anthropicService` from the retired `claude-sonnet-4-20250514` model (retired by Anthropic on 2026-06-15) to the recommended `claude-sonnet-4-6`. Made overridable via a new `ANTHROPIC_MODEL` env var (mirrors the existing `OPENAI_MODEL` pattern) and documented in `.env.example`.
- Updated now-stale "open tickets" wording/doc comments in the modal and API service.

## Test plan
- [ ] Open an Opp detail page, click "Link a Linear ticket", and confirm a completed/done ticket now appears and can be linked.
- [ ] Confirm canceled tickets still do not appear.
- [ ] Trigger an Anthropic-backed feature (e.g. flow-doc generator summary) and confirm it succeeds against `claude-sonnet-4-6`.

Made with [Cursor](https://cursor.com)